### PR TITLE
Simplify debug_print_shortest_route using Network class

### DIFF
--- a/data/doors.py
+++ b/data/doors.py
@@ -429,6 +429,7 @@ class Doors():
         """
         import networkx as nx
         from data.rooms import room_data
+        from data.walks import Network
 
         # Convert destination_room to appropriate type (try int first, then keep as string)
         try:
@@ -436,46 +437,26 @@ class Doors():
         except (ValueError, TypeError):
             pass  # Keep as string
 
-        # Build door-to-room mapping from room_data
-        door_to_room = {}
-        for room_id, data in room_data.items():
-            # data format: [doors, traps, pits, ...] or [doors, traps, pits, keys, locks, world]
-            doors = data[0] if len(data) > 0 else []
-            traps = data[1] if len(data) > 1 else []
-            pits = data[2] if len(data) > 2 else []
-
-            for door in doors:
-                door_to_room[door] = room_id
-            for trap in traps:
-                door_to_room[trap] = room_id
-            for pit in pits:
-                door_to_room[pit] = room_id
-
-        # Build a fresh network graph from the mapping
-        net = nx.DiGraph()
-        all_rooms = set()
+        # Build a fresh Network with all rooms from room_data
+        walks = Network(list(room_data.keys()))
 
         # Add edges from two-way door pairs
         for d1, d2 in door_map[0]:
-            r1 = door_to_room.get(d1)
-            r2 = door_to_room.get(d2)
+            r1 = walks.rooms.get_room_from_element(d1)
+            r2 = walks.rooms.get_room_from_element(d2)
             if r1 and r2:
-                all_rooms.add(r1)
-                all_rooms.add(r2)
-                net.add_edge(r1, r2)
-                net.add_edge(r2, r1)  # Two-way connection
+                walks.net.add_edge(r1.id, r2.id)
+                walks.net.add_edge(r2.id, r1.id)  # Two-way connection
 
         # Add edges from one-way pairs
         for d1, d2 in door_map[1]:
-            r1 = door_to_room.get(d1)
-            r2 = door_to_room.get(d2)
+            r1 = walks.rooms.get_room_from_element(d1)
+            r2 = walks.rooms.get_room_from_element(d2)
             if r1 and r2:
-                all_rooms.add(r1)
-                all_rooms.add(r2)
-                net.add_edge(r1, r2)  # One-way connection only
+                walks.net.add_edge(r1.id, r2.id)  # One-way connection only
 
         # Get all world map rooms (wob-* and wor-*)
-        world_map_rooms = [room_id for room_id in all_rooms
+        world_map_rooms = [room_id for room_id in walks.rooms.rooms
                           if isinstance(room_id, str) and (room_id.startswith('wob-') or room_id.startswith('wor-'))]
 
         if not world_map_rooms:
@@ -483,9 +464,9 @@ class Doors():
             return
 
         # Validate destination room exists
-        if destination_room not in all_rooms:
+        if destination_room not in walks.rooms.rooms:
             print(f"DEBUG ERROR: Destination room '{destination_room}' not found in network.")
-            print(f"Available rooms: {sorted([str(r) for r in all_rooms])}")
+            print(f"Available rooms: {sorted([str(r) for r in walks.rooms.rooms])}")
             return
 
         # Find shortest path from any world map room to destination
@@ -495,7 +476,7 @@ class Doors():
 
         for wm_room in world_map_rooms:
             try:
-                path = nx.shortest_path(net, source=wm_room, target=destination_room)
+                path = nx.shortest_path(walks.net, source=wm_room, target=destination_room)
                 if len(path) < shortest_length:
                     shortest_path = path
                     shortest_length = len(path)
@@ -520,7 +501,7 @@ class Doors():
             next_room = shortest_path[i + 1]
 
             # Find the door(s) connecting these rooms
-            connecting_doors = self._find_connecting_doors(door_map, door_to_room, net, current_room, next_room)
+            connecting_doors = self._find_connecting_doors(walks, door_map, current_room, next_room)
 
             if connecting_doors:
                 door_desc = connecting_doors
@@ -532,7 +513,7 @@ class Doors():
         print(f"{shortest_path[-1]}: (destination)")
         print("="*80 + "\n")
 
-    def _find_connecting_doors(self, door_map, door_to_room, net, room1, room2):
+    def _find_connecting_doors(self, walks, door_map, room1, room2):
         """Find the door(s) connecting two rooms using the door mapping."""
         # Helper to get door description from exit_data or event_exit_info
         def get_door_name(door_id):
@@ -544,23 +525,27 @@ class Doors():
                 return f"Door {door_id}"
 
         # Check if there's a reverse edge (for two-way doors)
-        has_reverse = net.has_edge(room2, room1)
+        has_reverse = walks.net.has_edge(room2, room1)
 
         # Search through two-way door mappings
         for d1, d2 in door_map[0]:
-            r1 = door_to_room.get(d1)
-            r2 = door_to_room.get(d2)
+            r1 = walks.rooms.get_room_from_element(d1)
+            r2 = walks.rooms.get_room_from_element(d2)
+            if not r1 or not r2:
+                continue
 
-            if (r1 == room1 and r2 == room2) or (r1 == room2 and r2 == room1):
+            if (r1.id == room1 and r2.id == room2) or (r1.id == room2 and r2.id == room1):
                 arrow = "<-->" if has_reverse else "-->"
                 return f"DOOR {d1} ({get_door_name(d1)}) {arrow} DOOR {d2} ({get_door_name(d2)})"
 
         # Search through one-way exit mappings
         for d1, d2 in door_map[1]:
-            r1 = door_to_room.get(d1)
-            r2 = door_to_room.get(d2)
+            r1 = walks.rooms.get_room_from_element(d1)
+            r2 = walks.rooms.get_room_from_element(d2)
+            if not r1 or not r2:
+                continue
 
-            if r1 == room1 and r2 == room2:
+            if r1.id == room1 and r2.id == room2:
                 return f"EXIT {d1} ({get_door_name(d1)}) --> ENTRANCE {d2} ({get_door_name(d2)})"
 
         return "(connection not found in map)"


### PR DESCRIPTION
Instead of manually building a door_to_room mapping, create a fresh Network instance with all rooms and use the built-in walks.rooms.get_room_from_element() method for lookups.