### PR TITLE
Fix esper slot check to account for character slots in ruination mode

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -1018,8 +1018,9 @@ class ruination_map():
             print(f'Pre-plan: Planned areas have {total_checks} checks, '
                   f'{total_character_slots} character slots, {total_esper_slots} esper slots')
 
-        # Check if we have enough esper slots
-        while total_esper_slots < self.Requested[1] and len(remaining_characters) > 0:
+        # Check if we have enough esper slots after accounting for character slots
+        # We need espers + planned characters, since character slots can't be used for espers
+        while total_esper_slots < self.Requested[1] + len(planned_characters) and len(remaining_characters) > 0:
             # Add another character to get more areas/esper slots
             new_char = remaining_characters.pop(0)
             planned_characters.append(new_char)


### PR DESCRIPTION
The check at line 1023 (previously 1022) was not accounting for the fact that some reward slots will be used for characters, not espers.

Example: With requirements of 6 characters and 9 espers, if starting party has 3 characters and we plan to obtain 3 more, then with 10 total esper slots, the old check (10 < 9) would pass. But 3 of those slots will be used for characters, leaving only 7 for espers (insufficient).

Now checks: total_esper_slots < requested_espers + planned_characters This ensures enough slots exist for BOTH characters AND espers.

Fixes first item in event/TODO.md "updates to branch matching code"