### PR TITLE
Improve dried meat handling in ruination mode

### DIFF
--- a/event/TODO.md
+++ b/event/TODO.md
@@ -13,7 +13,13 @@
 
 
 ## Updates to overall behavior of -ruin
-1. When Gau is a character, the item "dried meat" must be available for purchase in at least one shop.  Something similar is done in the original randomizer via the flag -sdm N (--shops-dried-meat), which enforces N shops with dried meat available.  For -ruin, we must ensure that this flag specifically makes this number of dried meat available in accessible item shops, as not all shops will be accessible in ruination mode.  Accessible shops may be in WoR towns with item shops (Kohlingen, Nikeah, Thamasa, South Figaro, Albrook, Tzen, Jidoor... Maranda?), plus WoR Figaro Castle, Returners Hideout, Phantom Train shops, and possibly the merchant at Gau's Dad's House (if the WoB version is used).  However, which shops are actually accessible depends on the branch mapping, which must be taken into account: the accessible shops must be used and NOT be gated by the Veldt check.  Probably this will require some modification of Veldt check to make sure that it is not added as a character check until some item shop has been added, and the list of pre-Veldt item shops must be recorded for forcing dried meat to be available.
+### COMPLETED (2026-01-14)
+1. ✅ **FIXED** - Dried meat availability for Gau: The -sdm flag now correctly ensures dried meat is available in accessible, non-Veldt-gated shops in ruination mode. Implementation includes:
+   - Tracking of accessible shops during map generation (event/ruination.py:1190-1196)
+   - Filtering of Veldt-gated shops via character dependency paths (event/ruination.py:1234-1317)
+   - Assignment of dried meat to filtered shops (data/shops.py:215-274)
+   - Optimization: skips Veldt-gating logic when Gau is not in planned characters
+   - Fallback: uses all accessible shops with warning if no non-Veldt-gated shops exist
 
 2. Implement -ruin as a "meta-flag", that sets a default flagset which can subsequently be modified by calling other flags.  This bakes in some desired flags to -ruin while allowing the player flexibility to define other options.  The option of `-ruin minimum` could skip the defaults and require the player to choose everything.
 - Default flags include:

--- a/event/events.py
+++ b/event/events.py
@@ -249,7 +249,10 @@ class Events():
         self.maps.doors.map = ruin_map.generate_map_with_characters(self.characters, self.espers, self.items)
 
         # Handle dried meat for Gau: ensure it's available in non-Veldt-gated shops
+        # This ensures dried meat is accessible BEFORE Gau is obtained (needed for Veldt recruitment)
         if self.args.shop_dried_meat > 0:
+            if self.args.debug and 'GAU' in ruin_map.planned_characters:
+                print(f'Gau is in planned characters, ensuring dried meat in {self.args.shop_dried_meat} non-Veldt-gated shops')
             non_veldt_shops = ruin_map.get_non_veldt_gated_shops(self.characters)
             self.shops.assign_dried_meats_ruination(non_veldt_shops)
 

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -1234,6 +1234,9 @@ class ruination_map():
     def get_non_veldt_gated_shops(self, characters):
         """Identify shops that are NOT gated behind the Veldt reward.
 
+        This is necessary to ensure dried meat is available BEFORE Gau is obtained,
+        since dried meat is required to recruit Gau on the Veldt.
+
         Uses characters.character_path to determine which characters depend on
         the Veldt character. Shops in areas unlocked by those characters are
         considered Veldt-gated and excluded from dried meat assignment.
@@ -1244,6 +1247,12 @@ class ruination_map():
         Returns:
             List of shop IDs that are NOT Veldt-gated
         """
+        # Quick check: if Gau is not in planned characters, no need for special Veldt handling
+        if 'GAU' not in self.planned_characters:
+            if self.verbose:
+                print('Gau not in planned characters, all accessible shops valid for dried meat')
+            return self.accessible_shops[:]
+
         # Find which character was assigned to the Veldt reward
         veldt_reward_room = 'wor-veldt'
         veldt_char_id = None
@@ -1297,6 +1306,13 @@ class ruination_map():
             print(f'Accessible shops: {len(self.accessible_shops)}')
             print(f'Veldt-gated shops: {list(veldt_gated_shops)}')
             print(f'Non-Veldt-gated shops: {len(non_veldt_shops)} - {non_veldt_shops}')
+
+        # Warn if no non-Veldt-gated shops exist when Gau is in the game
+        if not non_veldt_shops and 'GAU' in self.planned_characters:
+            print('WARNING: No non-Veldt-gated shops available for dried meat!')
+            print('  This may make Gau unrecrutable. Consider adjusting map generation.')
+            print(f'  Falling back to all {len(self.accessible_shops)} accessible shops.')
+            return self.accessible_shops[:]
 
         return non_veldt_shops
 


### PR DESCRIPTION
Enhanced the dried meat assignment logic with better checks and error handling:

1. Early optimization: Skip Veldt-gating logic when Gau is not in planned characters
2. Better documentation: Added comments explaining why Veldt-gating is necessary
3. Improved error handling: Fallback to all accessible shops with warning if no non-Veldt-gated shops exist
4. Debug logging: Added helpful debug output when Gau is in planned characters

Updated TODO.md to mark dried meat fix as completed with implementation details.