### PR TITLE
Fix NoneType error when terminus room is merged into hub

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -545,18 +545,24 @@ class RuinationBranch(Network):
             self.connect(this_exit, this_conn)
 
         # (4) The terminus is currently always a dead end room.  Connect it.
+        # However, the terminus may have been merged into the hub through loop compression.
+        # If so, we skip this step since the terminus is already connected.
         remaining_doors = [d for d in hub.doors]
         random.shuffle(remaining_doors)
         if self.verbose:
             print('(4) remaining doors:', remaining_doors)
-        this_exit = remaining_doors.pop()
         terminus = self.rooms.get_room(self.terminus)
-        if self.terminus in self.dead_ends:
-            self.dead_ends.remove(self.terminus)
-        this_conn = terminus.doors.pop()
-        if self.verbose:
-            print('(4) connecting terminus:', this_exit , '-->', this_conn)
-        self.connect(this_exit, this_conn)
+        if terminus is not None:
+            # Terminus is still a separate room - connect it
+            this_exit = remaining_doors.pop()
+            if self.terminus in self.dead_ends:
+                self.dead_ends.remove(self.terminus)
+            this_conn = terminus.doors.pop()
+            if self.verbose:
+                print('(4) connecting terminus:', this_exit , '-->', this_conn)
+            self.connect(this_exit, this_conn)
+        elif self.verbose:
+            print('(4) terminus already merged into hub, skipping')
 
         # (5) Count doors in hub.  Connect doors within hub until # doors < # dead ends
         # Clean up dead ends first


### PR DESCRIPTION
In finalize_map(), the terminus room can get merged into the hub through loop compression during map generation. When this happens, the original terminus room ID no longer exists as a separate room, causing self.rooms.get_room(self.terminus) to return None.

Added a check for this case - when terminus is already merged into the hub, we skip the explicit terminus connection since it's already connected via the loop compression.