### PR TITLE
Fix _element_to_room not updating when elements added via add_doors/a…

### DIFF
--- a/data/walks.py
+++ b/data/walks.py
@@ -1258,6 +1258,9 @@ class Room:
         for element in elements:
             validated = self._validate_element(element, element_type)
             self.elements[element_type].add(validated)
+            # Update parent's element-to-room mapping
+            if self.rooms_ref is not None:
+                self.rooms_ref._element_to_room[validated] = self.id
 
     def add_doors(self, doors):
         self._add_elements('doors', doors)


### PR DESCRIPTION
…dd_traps/add_pits

When apply_key() unlocks elements and moves them from locks to doors/traps, the Room._add_elements() method was adding to the room's elements but not updating the parent Rooms collection's _element_to_room mapping. This caused get_room_from_element() to return stale room IDs for unlocked elements, leading to duplicate exit mappings.

The fix updates _element_to_room in _add_elements() when a parent Rooms reference is available, similar to how add_locks() notifies its parent.