### PR TITLE
Fix KeyError in apply_key when recursive calls pop locks

### DIFF
--- a/data/walks.py
+++ b/data/walks.py
@@ -148,6 +148,9 @@ class Network:
             #if key in room.locks.keys():
             room_keys = [k for k in room.locks.keys()]
             for required_keys in room_keys:
+                # Check if key still exists - recursive apply_key calls may have already popped it
+                if required_keys not in room.locks:
+                    continue
                 if set(required_keys).issubset(self.keychain):
                     if self.verbose:
                         print('\t\t\tApplying key:', required_keys, 'in room', room.id)


### PR DESCRIPTION
When a room has multiple locks (e.g., ('CYAN',) and ('zr1',)), and processing one lock triggers a recursive apply_key call that pops another lock from the same room, the outer loop would fail trying to pop the already-removed key.

Added a check to skip lock keys that have already been popped by recursive calls before attempting to process them.