### PR TITLE
Fix missing args parameter in disable_chocobo_stables

### DIFF
--- a/claude_reference/output_260119_1727.txt
+++ b/claude_reference/output_260119_1727.txt
@@ -1,0 +1,2489 @@
+Version   1.4.2
+Generated 2026-01-19 17:27:15
+Input     FFIII.smc
+Output    ruin.smc
+Log       ruin.txt
+Seed      yocg6yf6v0a2
+Flags     -oa 2.2.2.2.6.6.4.9.9 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 0 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 6 14 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 5 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -etn -ruin
+Hash      Ultros, Chancellor, Rachel, Suit Gau
+Requested:  6 characters,  9 espers
+Pre-plan: Planned areas have 15 checks, 13 character slots, 15 esper slots
+Pre-plan: Will obtain characters: ['CYAN', 'STRAGO', 'GOGO']
+Pre-plan: Reserve characters (for extra areas): ['RELM', 'UMARO', 'SABIN', 'SETZER', 'EDGAR', 'MOG', 'SHADOW', 'CELES']
+Pre-plan: Dead checks allowed: 3
+Areas used:  {'Kohlingen', 'Veldt', 'PhoenixCave', 'Narshe', 'ZozoTower', 'Zozo', 'Nikeah', 'Mobliz', 'ReturnersHideout', 'SealedGate', 'CrescentMtn', 'SouthFigaroCave'}
+Forced same branch: Zozo ZozoTower 1
+Forced same branch: CrescentMtn Nikeah 2
+Distributed areas:
+	 0 :  {'Mobliz', 'Narshe'}
+	 1 :  {'Veldt', 'Zozo', 'ZozoTower', 'SealedGate', 'ReturnersHideout'}
+	 2 :  {'Kohlingen', 'PhoenixCave', 'Nikeah', 'CrescentMtn', 'SouthFigaroCave'}
+Checks available:
+	 0 :  ['Whelk']
+	 1 :  ['Lete River', 'Zozo', 'Veldt']
+	 2 :  ['South Figaro Cave', 'Serpent Trench']
+CUSTOM add pit 3039 to ruin_hub_1 ! [1, 0, 1, 0, 0] [3039]
+Rewards available:  [6, 6]
+		assessing key  LOCKE in rooms
+		assessing key  TERRA in rooms
+			Applying key: ('TERRA',) in room ruin-whelk
+			adding a door... 1155
+		assessing key  GAU in rooms
+		assessing key  LOCKE in rooms
+		assessing key  TERRA in rooms
+			Applying key: ('TERRA',) in room ruin-zozo
+			adding a door... 608
+		assessing key  GAU in rooms
+		assessing key  LOCKE in rooms
+		assessing key  TERRA in rooms
+		assessing key  GAU in rooms
+Generating map with characters...
+Branch viability: [True, True, True] Stuck: set()
+Working on branch 0 ( ['Whelk'] )
+status: terminus ruin_terminus_2
+status: check rooms [65, 'ruin-whelk']
+status: dead ends ['ruin_hub_0', 'ruin_terminus_2', 'ms-wor-52', 41, 47]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 37 doors, 1 pits
+	Total doors in connected path: 1
+	Trying door exit: 393 in room ruin_hub_0
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 33 connections, selected: 179 in room ruin-whelk
+Looking for reward in room ruin-whelk ...
+Found a reward!  [('Whelk', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room ruin-whelk
+Making connection:  393 --> 179
+Processing reward:  Whelk
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got GOGO !
+	Set character path: GOGO depends on TERRA
+		assessing key  GOGO in rooms
+		assessing key  GOGO in rooms
+		assessing key  GOGO in rooms
+		# rooms on each branch:  [19, 44, 21]
+Distributed areas:
+	 0 :  {'ZoneEater'}
+	 1 :  set()
+	 2 :  set()
+Checks available:
+	 0 :  ['Whelk', 'Zone Eater']
+	 1 :  ['Lete River', 'Zozo', 'Veldt']
+	 2 :  ['South Figaro Cave', 'Serpent Trench']
+	Updated Rewards Obtained:  1 Characters,  0 Espers
+	Updated Rewards Available:  6 Characters,  6 Espers
+	Updated branch checks available:
+	 0 :  ['Zone Eater']
+	 1 :  ['Lete River', 'Zozo', 'Veldt']
+	 2 :  ['South Figaro Cave', 'Serpent Trench']
+Branch viability: [True, True, True] Stuck: set()
+Working on branch 1 ( ['Lete River', 'Zozo', 'Veldt'] )
+status: terminus ruin_terminus_1
+status: check rooms [313, 'LeteRiver3', 'wor-veldt']
+status: dead ends ['ruin_hub_1', 'ruin_terminus_1', 513, '295r', '305r', 'branch-mz_mapsafe', 310, 312, 313, '309r', '294r', '306r', 'wor-veldt', 504, 511]
+Forcing connections...
+Forcing:  2029 3029
+forcing successful.
+Forcing:  2030 3030
+forcing successful.
+Forcing:  2032 3032
+forcing successful.
+Forcing:  2033 3033
+forcing successful.
+Forcing:  2064 3064
+forcing successful.
+Forcing:  2039 3039
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_1 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 63 doors, 5 pits
+	Total doors in connected path: 1
+	Trying door exit: 394 in room ruin_hub_1
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 42 connections, selected: 1067 in room 506
+Looking for reward in room 506 ...
+Making connection:  394 --> 1067
+	Active room:  506_ruin_hub_1 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 61 doors, 5 pits
+	Total doors in connected path: 1
+	Trying door exit: 1066 in room 506_ruin_hub_1
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 40 connections, selected: 1263 in room 502
+Looking for reward in room 502 ...
+Making connection:  1066 --> 1263
+	Active room:  502_506_ruin_hub_1 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 58 doors, 5 pits
+	Total doors in connected path: 2
+	Trying door exit: 1058 in room 502_506_ruin_hub_1
+		Filtered out path doors (path has only 2 doors)
+	Found 38 connections, selected: 4622 in room 301r
+Looking for reward in room 301r ...
+Making connection:  1058 --> 4622
+		assessing key  clock1 in rooms
+			removing key  clock1 from 301r_502_506_ruin_hub_1
+	Active room:  301r_502_506_ruin_hub_1 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 55 doors, 5 pits
+	Total doors in connected path: 3
+	Trying door exit: 4621 in room 301r_502_506_ruin_hub_1
+	Found 35 connections, selected: 1072 in room 509
+Looking for reward in room 509 ...
+Making connection:  4621 --> 1072
+	Active room:  509_301r_502_506_ruin_hub_1 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  [510, 508]
+	Available exits: 1 doors, 0 traps
+	Available entrances: 51 doors, 5 pits
+	Total doors in connected path: 5
+	Trying door exit: 1070 in room 508
+	Found 36 connections, selected: 1061 in room 503
+Looking for reward in room 503 ...
+Making connection:  1070 --> 1061
+	Active room:  503_508 .
+	Upstream nodes:  [510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 49 doors, 5 pits
+	Total doors in connected path: 5
+	Trying door exit: 1062 in room 503_508
+	Found 34 connections, selected: 611 in room 298
+Looking for reward in room 298 ...
+Making connection:  1062 --> 611
+	Active room:  298_503_508 .
+	Upstream nodes:  [510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  [297]
+	Available exits: 2 doors, 0 traps
+	Available entrances: 44 doors, 5 pits
+	Total doors in connected path: 8
+	Trying door exit: 610 in room 297
+	Found 30 connections, selected: 5224 in room ruin-zozo
+Looking for reward in room ruin-zozo ...
+Making connection:  610 --> 5224
+	Active room:  ruin-zozo_297 .
+	Upstream nodes:  ['298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 38 doors, 5 pits
+	Total doors in connected path: 12
+	Trying door exit: 4602 in room ruin-zozo_297
+	Found 24 connections, selected: 4607 in room 296r
+Looking for reward in room 296r ...
+Making connection:  4602 --> 4607
+	Active room:  296r_ruin-zozo_297 .
+	Upstream nodes:  ['298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 36 doors, 5 pits
+	Total doors in connected path: 12
+	Trying door exit: 4604 in room 296r_ruin-zozo_297
+	Found 22 connections, selected: 1069 in room 507
+Looking for reward in room 507 ...
+Making connection:  4604 --> 1069
+	Active room:  507_296r_ruin-zozo_297 .
+	Upstream nodes:  ['298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 1 traps
+	Available entrances: 34 doors, 5 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2031 in room 507_296r_ruin-zozo_297
+	Found 6 connections, selected: 3035 in room LeteCave1
+Looking for reward in room LeteCave1 ...
+Making connection:  2031 --> 3035
+	Active room:  LeteCave1 .
+	Upstream nodes:  ['507_296r_ruin-zozo_297', '298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 34 doors, 4 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2036 in room LeteCave1
+	Found 5 connections, selected: 3037 in room LeteCave2
+Looking for reward in room LeteCave2 ...
+Making connection:  2036 --> 3037
+	Active room:  LeteCave2 .
+	Upstream nodes:  ['LeteCave1', '507_296r_ruin-zozo_297', '298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 34 doors, 3 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2038 in room LeteCave2
+	Found 4 connections, selected: 3031 in room 505
+Looking for reward in room 505 ...
+Making connection:  2038 --> 3031
+	Active room:  505 .
+	Upstream nodes:  ['LeteCave2', 'LeteCave1', '507_296r_ruin-zozo_297', '298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 32 doors, 2 pits
+	Total doors in connected path: 14
+	Trying door exit: 1065 in room 505
+	Found 26 connections, selected: 635 in room 311
+Looking for reward in room 311 ...
+Making connection:  1065 --> 635
+	Active room:  311_505 .
+	Upstream nodes:  ['LeteCave2', 'LeteCave1', '507_296r_ruin-zozo_297', '298_503_508', 510, '509_301r_502_506_ruin_hub_1', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 30 doors, 2 pits
+	Total doors in connected path: 14
+	Trying door exit: 1064 in room 311_505
+	Found 24 connections, selected: 4620 in room 509_301r_502_506_ruin_hub_1
+Looking for reward in room 509_301r_502_506_ruin_hub_1 ...
+Making connection:  1064 --> 4620
+	Active room:  LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 12 doors, 0 traps
+	Available entrances: 30 doors, 2 pits
+	Total doors in connected path: 12
+	Trying door exit: 4606 in room LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Found 12 connections, selected: 619 in room 300
+Looking for reward in room 300 ...
+Making connection:  4606 --> 619
+	Active room:  300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 27 doors, 2 pits
+	Total doors in connected path: 13
+	Trying door exit: 1059 in room 300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Found 9 connections, selected: 613 in room 299
+Looking for reward in room 299 ...
+Making connection:  1059 --> 613
+		assessing key  clock5 in rooms
+			removing key  clock5 from 299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Active room:  299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 25 doors, 2 pits
+	Total doors in connected path: 13
+	Trying door exit: 609 in room 299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Found 7 connections, selected: 628 in room 304
+Looking for reward in room 304 ...
+Making connection:  609 --> 628
+		assessing key  clock4 in rooms
+			removing key  clock4 from 304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Active room:  304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 23 doors, 2 pits
+	Total doors in connected path: 13
+	Trying door exit: 1264 in room 304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Found 5 connections, selected: 399 in room ruin-returners
+Looking for reward in room ruin-returners ...
+Making connection:  1264 --> 399
+	Active room:  ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 12 doors, 1 traps
+	Available entrances: 22 doors, 2 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2034 in room ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505
+	Found 2 connections, selected: 3036 in room LeteRiver2
+Looking for reward in room LeteRiver2 ...
+Making connection:  2034 --> 3036
+	Active room:  LeteRiver2 .
+	Upstream nodes:  ['ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 22 doors, 1 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2037 in room LeteRiver2
+	Found 2 connections, selected: 3034 in room LeteRiver1
+Looking for reward in room LeteRiver1 ...
+Making connection:  2037 --> 3034
+	Active room:  LeteRiver1 .
+	Upstream nodes:  ['LeteRiver2', 'ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 22 doors, 0 pits
+	Total doors in connected path: 12
+	Trying trap exit: 2035 in room LeteRiver1
+	Found 1 connections, selected: 3038 in room LeteRiver3
+Looking for reward in room LeteRiver3 ...
+Found a reward!  [('Lete River', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room LeteRiver3
+Making connection:  2035 --> 3038
+Processing reward:  Lete River
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got CYAN !
+	Set character path: CYAN depends on TERRA
+		assessing key  CYAN in rooms
+		assessing key  CYAN in rooms
+			Applying key: ('CYAN',) in room LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+			Applying a new key: zr1
+		assessing key  zr1 in rooms
+			Applying key: ('zr1',) in room LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+			adding a door... 618
+		assessing key  CYAN in rooms
+		# rooms on each branch:  [28, 44, 21]
+Forced same branch: MtZozo Zozo 1
+		# rooms on each branch:  [28, 52, 54]
+Distributed areas:
+	 0 :  {'Maranda'}
+	 1 :  {'MtZozo'}
+	 2 :  {'Doma'}
+Checks available:
+	 0 :  ['Zone Eater']
+	 1 :  ['Lete River', 'Zozo', 'Veldt', 'Mt. Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	Updated Rewards Obtained:  2 Characters,  0 Espers
+	Updated Rewards Available:  7 Characters,  9 Espers
+	Updated branch checks available:
+	 0 :  ['Zone Eater']
+	 1 :  ['Zozo', 'Veldt', 'Mt. Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, True, True] Stuck: set()
+	trimmed dead end  ruin_hub_1
+Working on branch 1 ( ['Zozo', 'Veldt', 'Mt. Zozo'] )
+status: terminus ruin_terminus_1
+status: check rooms [313, 'wor-veldt', 256]
+status: dead ends ['ruin_terminus_1', 513, '295r', '305r', 'branch-mz_mapsafe', 310, 312, 313, '309r', '294r', '306r', 'wor-veldt', 504, 511, 256, 'root-mz_mapsafe', 251]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 36 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 612 in room LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 15 connections, selected: 1077 in room 512
+Looking for reward in room 512 ...
+Making connection:  612 --> 1077
+	Active room:  512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 34 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 4601 in room 512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 13 connections, selected: 535 in room 252
+Looking for reward in room 252 ...
+Making connection:  4601 --> 535
+	Active room:  252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 32 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 627 in room 252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 11 connections, selected: 537 in room 253
+Looking for reward in room 253 ...
+Making connection:  627 --> 537
+	Active room:  253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 29 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 615 in room 253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 8 connections, selected: 533 in room 250
+Looking for reward in room 250 ...
+Making connection:  615 --> 533
+	Active room:  250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 27 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 1073 in room 250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 6 connections, selected: 543 in room 255
+Looking for reward in room 255 ...
+Making connection:  1073 --> 543
+	Active room:  255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 25 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 4600 in room 255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 4 connections, selected: 541 in room 254
+Looking for reward in room 254 ...
+Making connection:  4600 --> 541
+	Active room:  254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 23 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 1075 in room 254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+	Found 2 connections, selected: 624 in room 302
+Looking for reward in room 302 ...
+Making connection:  1075 --> 624
+	Active room:  302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 21 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 617 in room 302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+		Expanding search to all unconnected rooms...
+	Found 21 connections, selected: 637 in room 312
+Looking for reward in room 312 ...
+Making connection:  617 --> 637
+	Active room:  312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 20 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 540 in room 312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+		Expanding search to all unconnected rooms...
+	Found 20 connections, selected: 4632 in room 308r
+Looking for reward in room 308r ...
+Making connection:  540 --> 4632
+	Active room:  308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  ['307r']
+	Available exits: 1 doors, 0 traps
+	Available entrances: 18 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 4631 in room 307r
+	Found 12 connections, selected: 536 in room 308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1
+Looking for reward in room 308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1 ...
+Making connection:  4631 --> 536
+	Active room:  308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 11 doors, 0 traps
+	Available entrances: 18 doors, 0 pits
+	Total doors in connected path: 11
+	Trying door exit: 542 in room 308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 18 connections, selected: 1078 in room 513
+Looking for reward in room 513 ...
+Making connection:  542 --> 1078
+	Active room:  513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 10 doors, 0 traps
+	Available entrances: 17 doors, 0 pits
+	Total doors in connected path: 10
+	Trying door exit: 539 in room 513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 17 connections, selected: 1063 in room 504
+Looking for reward in room 504 ...
+Making connection:  539 --> 1063
+	Active room:  504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 9 doors, 0 traps
+	Available entrances: 16 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 1071 in room 504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 16 connections, selected: 4603 in room 294r
+Looking for reward in room 294r ...
+Making connection:  1071 --> 4603
+	Active room:  294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 8 doors, 0 traps
+	Available entrances: 15 doors, 0 pits
+	Total doors in connected path: 8
+	Trying door exit: 614 in room 294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 15 connections, selected: 4633 in room 309r
+Looking for reward in room 309r ...
+Making connection:  614 --> 4633
+	Active room:  309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 7 doors, 0 traps
+	Available entrances: 14 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 623 in room 309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 14 connections, selected: 4605 in room 295r
+Looking for reward in room 295r ...
+Making connection:  623 --> 4605
+	Active room:  295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 13 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 531 in room 295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 13 connections, selected: 1074 in room 511
+Looking for reward in room 511 ...
+Making connection:  531 --> 1074
+	Active room:  511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 12 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 538 in room 511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 12 connections, selected: 30618 in room root-mz_mapsafe
+Looking for reward in room root-mz_mapsafe ...
+Making connection:  538 --> 30618
+	Active room:  root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 11 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 616 in room root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 11 connections, selected: 4629 in room 305r
+Looking for reward in room 305r ...
+Making connection:  616 --> 4629
+	Active room:  305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 10 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 636 in room 305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 10 connections, selected: 61 in room wor-veldt
+Looking for reward in room wor-veldt ...
+Found a reward!  [('Veldt', <RewardType.ESPER|CHARACTER: 6>)] in room wor-veldt
+Making connection:  636 --> 61
+Processing reward:  Veldt
+	choosing from... RewardType.ESPER|CHARACTER
+	got Terrato !
+	Updated Rewards Obtained:  2 Characters,  1 Espers
+	Updated Rewards Available:  6 Characters,  8 Espers
+	Updated branch checks available:
+	 0 :  ['Zone Eater']
+	 1 :  ['Zozo', 'Mt. Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, False, True] Stuck: set()
+Working on branch 2 ( ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3'] )
+status: terminus ruin_terminus_3
+status: check rooms ['ruin-st-exit', 'ms-wor-59', 104, 'dc-76', 429, 193]
+status: dead ends ['ruin_hub_2', 'ruin_terminus_3', 'ms-wor-1554', 103, '221R', 426, 184, 185, 189, 190, 192]
+Forcing connections...
+Forcing:  2046 3046
+forcing successful.
+Forcing:  2049 3049
+forcing successful.
+Forcing:  2053 3053
+forcing successful.
+Forcing:  2153 3153
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 65 doors, 25 pits
+	Total doors in connected path: 1
+	Trying door exit: 395 in room ruin_hub_2
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 42 connections, selected: 452 in room 188
+Looking for reward in room 188 ...
+Making connection:  395 --> 452
+	Active room:  188_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 58 doors, 25 pits
+	Total doors in connected path: 6
+	Trying door exit: 454 in room 188_ruin_hub_2
+	Found 43 connections, selected: 858 in room 430
+Looking for reward in room 430 ...
+Making connection:  454 --> 858
+	Active room:  430_188_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 1 traps
+	Available entrances: 57 doors, 24 pits
+	Total doors in connected path: 5
+	Trying trap exit: 859 in room 430_188_ruin_hub_2
+	Found 24 connections, selected: 6853 in room 428
+Looking for reward in room 428 ...
+Making connection:  859 --> 6853
+	Active room:  428 .
+	Upstream nodes:  ['430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 1 traps
+	Available entrances: 56 doors, 22 pits
+	Total doors in connected path: 6
+	Trying trap exit: 854 in room 428
+	Found 23 connections, selected: 6846 in room 421
+Looking for reward in room 421 ...
+Making connection:  854 --> 6846
+	Active room:  421 .
+	Upstream nodes:  [428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 2 traps
+	Available entrances: 56 doors, 20 pits
+	Total doors in connected path: 6
+	Trying trap exit: 844 in room 421
+	Found 21 connections, selected: 3048 in room 247a
+Looking for reward in room 247a ...
+Making connection:  844 --> 3048
+	Active room:  247a .
+	Upstream nodes:  [421, 428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 55 doors, 19 pits
+	Total doors in connected path: 7
+	Trying door exit: 529 in room 247a
+	Found 46 connections, selected: 268 in room 102
+Looking for reward in room 102 ...
+Making connection:  529 --> 268
+	Active room:  102_247a .
+	Upstream nodes:  [421, 428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 53 doors, 19 pits
+	Total doors in connected path: 7
+	Trying door exit: 269 in room 102_247a
+	Found 44 connections, selected: 850 in room 425
+Looking for reward in room 425 ...
+Making connection:  269 --> 850
+	Active room:  425_102_247a .
+	Upstream nodes:  [421, 428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 52 doors, 17 pits
+	Total doors in connected path: 6
+		Filtering exit 852 - would strand pits in 425_102_247a
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 failed to extend, retry 1/3
+	Active room:  425_102_247a .
+	Upstream nodes:  [421, 428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 52 doors, 17 pits
+	Total doors in connected path: 6
+		Filtering exit 852 - would strand pits in 425_102_247a
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 failed to extend, retry 2/3
+	Active room:  425_102_247a .
+	Upstream nodes:  [421, 428, '430_188_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 52 doors, 17 pits
+	Total doors in connected path: 6
+		Filtering exit 852 - would strand pits in 425_102_247a
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 is stuck after 3 retries
+Skipping reward processing for stuck branch 2
+Branch viability: [True, False, True] Stuck: {2}
+	trimmed dead end  ruin_hub_0
+Working on branch 0 ( ['Zone Eater'] )
+status: terminus ruin_terminus_2
+status: check rooms [65, 363]
+status: dead ends ['ruin_terminus_2', 'ms-wor-52', 41, 47, 363]
+Forcing connections...
+Forcing:  2043 3043
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 50 doors, 3 pits
+	Total doors in connected path: 2
+	Trying door exit: 178 in room ruin-whelk_ruin_hub_0
+		Filtered out path doors (path has only 2 doors)
+	Found 44 connections, selected: 727 in room 362
+Looking for reward in room 362 ...
+Making connection:  178 --> 727
+	Active room:  362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 48 doors, 3 pits
+	Total doors in connected path: 2
+	Trying door exit: 1155 in room 362_ruin-whelk_ruin_hub_0
+		Filtered out path doors (path has only 2 doors)
+	Found 42 connections, selected: 5238 in room ms-wor-63
+Looking for reward in room ms-wor-63 ...
+Making connection:  1155 --> 5238
+	Active room:  ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 46 doors, 3 pits
+	Total doors in connected path: 2
+	Trying door exit: 728 in room ms-wor-63_362_ruin-whelk_ruin_hub_0
+		Filtered out path doors (path has only 2 doors)
+	Found 40 connections, selected: 1146 in room ruin-narshe
+Looking for reward in room ruin-narshe ...
+Making connection:  728 --> 1146
+	Active room:  ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 42 doors, 3 pits
+	Total doors in connected path: 4
+	Trying door exit: 5239 in room ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 36 connections, selected: 1510 in room 359b
+Looking for reward in room 359b ...
+Making connection:  5239 --> 1510
+	Active room:  359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 40 doors, 3 pits
+	Total doors in connected path: 4
+	Trying door exit: 143 in room 359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 34 connections, selected: 146 in room 37a
+Looking for reward in room 37a ...
+Making connection:  143 --> 146
+	Active room:  37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 38 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 145 in room 37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 32 connections, selected: 166 in room 50
+Looking for reward in room 50 ...
+Making connection:  145 --> 166
+	Active room:  50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 36 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 1143 in room 50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 30 connections, selected: 141 in room 36
+Looking for reward in room 36 ...
+Making connection:  1143 --> 141
+	Active room:  36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 34 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 142 in room 36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 28 connections, selected: 148 in room 42
+Looking for reward in room 42 ...
+Making connection:  142 --> 148
+	Active room:  42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 32 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 1511 in room 42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 26 connections, selected: 722 in room 361
+Looking for reward in room 361 ...
+Making connection:  1511 --> 722
+	Active room:  361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 30 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 149 in room 361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 24 connections, selected: 154 in room 45
+Looking for reward in room 45 ...
+Making connection:  149 --> 154
+	Active room:  45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 28 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 155 in room 45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 22 connections, selected: 725 in room 359
+Looking for reward in room 359 ...
+Making connection:  155 --> 725
+	Active room:  359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 26 doors, 2 pits
+	Total doors in connected path: 4
+	Trying door exit: 165 in room 359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 20 connections, selected: 721 in room 357
+Looking for reward in room 357 ...
+Making connection:  165 --> 721
+	Active room:  357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 1 traps
+	Available entrances: 23 doors, 2 pits
+	Total doors in connected path: 5
+	Trying trap exit: 2042 in room 357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+	Found 2 connections, selected: 3040 in room 356
+Looking for reward in room 356 ...
+Making connection:  2042 --> 3040
+	Active room:  356 .
+	Upstream nodes:  ['357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 1 traps
+	Available entrances: 22 doors, 1 pits
+	Total doors in connected path: 6
+	Trying trap exit: 2041 in room 356
+	Found 2 connections, selected: 3042 in room 358
+Looking for reward in room 358 ...
+Making connection:  2041 --> 3042
+	Active room:  358 .
+	Upstream nodes:  [356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  ['358b']
+	Available exits: 1 doors, 0 traps
+	Available entrances: 21 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 720 in room 358b
+	Found 21 connections, selected: 152 in room 44
+Looking for reward in room 44 ...
+Making connection:  720 --> 152
+	Active room:  44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 19 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 153 in room 44_358b
+	Found 19 connections, selected: 168 in room 51
+Looking for reward in room 51 ...
+Making connection:  153 --> 168
+	Active room:  51_44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 17 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 167 in room 51_44_358b
+	Found 17 connections, selected: 164 in room 49
+Looking for reward in room 49 ...
+Making connection:  167 --> 164
+	Active room:  49_51_44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 13 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 161 in room 49_51_44_358b
+	Found 13 connections, selected: 1148 in room 40
+Looking for reward in room 40 ...
+Making connection:  161 --> 1148
+	Active room:  40_49_51_44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 11 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 1149 in room 40_49_51_44_358b
+	Found 11 connections, selected: 151 in room 43
+Looking for reward in room 43 ...
+Making connection:  1149 --> 151
+	Active room:  43_40_49_51_44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 9 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 163 in room 43_40_49_51_44_358b
+	Found 9 connections, selected: 147 in room 38
+Looking for reward in room 38 ...
+Making connection:  163 --> 147
+	Active room:  38_43_40_49_51_44_358b .
+	Upstream nodes:  [358, 356, '357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 7 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 162 in room 38_43_40_49_51_44_358b
+	Found 7 connections, selected: 723 in room 357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0
+Looking for reward in room 357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0 ...
+Making connection:  162 --> 723
+	Active room:  358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 7 doors, 0 traps
+	Available entrances: 7 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 718 in room 358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+	Found 2 connections, selected: 192 in room 65
+Looking for reward in room 65 ...
+Found a reward!  [('Narshe Moogle Defense', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 65
+		reward is locked by MOG . Saving for later.
+Making connection:  718 --> 192
+	Active room:  65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 7 doors, 0 traps
+	Available entrances: 5 doors, 0 pits
+	Total doors in connected path: 7
+	Trying door exit: 191 in room 65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+	Found 5 connections, selected: 1192 in room ms-wor-52
+Looking for reward in room ms-wor-52 ...
+Making connection:  191 --> 1192
+	Active room:  ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 726 in room ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+	Found 4 connections, selected: 724 in room 363
+Looking for reward in room 363 ...
+Found a reward!  [('Zone Eater', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 363
+Making connection:  726 --> 724
+Processing reward:  Zone Eater
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got ZoneSeek !
+	Updated Rewards Obtained:  2 Characters,  2 Espers
+	Updated Rewards Available:  5 Characters,  7 Espers
+	Updated branch checks available:
+	 0 :  []
+	 1 :  ['Zozo', 'Mt. Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, False, True] Stuck: {2}
+Adding reserve area MtKolts (16 rooms) to unstick branch 1
+	Added new check: Mt. Kolts
+	trimmed dead end  513
+	trimmed dead end  295r
+	trimmed dead end  305r
+	trimmed dead end  312
+	trimmed dead end  309r
+	trimmed dead end  294r
+	trimmed dead end  wor-veldt
+	trimmed dead end  504
+	trimmed dead end  511
+	trimmed dead end  root-mz_mapsafe
+Working on branch 1 ( ['Zozo', 'Mt. Zozo', 'Mt. Kolts'] )
+status: terminus ruin_terminus_1
+status: check rooms [313, 256, 151]
+status: dead ends ['ruin_terminus_1', 'branch-mz_mapsafe', 310, 313, '306r', 256, 251, 147, 149, 157]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 41 doors, 0 pits
+	Total doors in connected path: 2
+	Trying door exit: 618 in room wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Filtered out path doors (path has only 2 doors)
+	Found 29 connections, selected: 1177 in room 158
+Looking for reward in room 158 ...
+Making connection:  618 --> 1177
+	Active room:  158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 39 doors, 0 pits
+	Total doors in connected path: 2
+	Trying door exit: 608 in room 158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Filtered out path doors (path has only 2 doors)
+	Found 27 connections, selected: 376 in room 153
+Looking for reward in room 153 ...
+Making connection:  608 --> 376
+	Active room:  153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 35 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 1178 in room 153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 23 connections, selected: 379 in room 154
+Looking for reward in room 154 ...
+Making connection:  1178 --> 379
+	Active room:  154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 33 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 380 in room 154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 21 connections, selected: 364 in room 146
+Looking for reward in room 146 ...
+Making connection:  380 --> 364
+	Active room:  146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 31 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 377 in room 146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 19 connections, selected: 375 in room 152
+Looking for reward in room 152 ...
+Making connection:  377 --> 375
+	Active room:  152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 29 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 378 in room 152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 17 connections, selected: 373 in room 151
+Looking for reward in room 151 ...
+Found a reward!  [('Mt. Kolts', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 151
+Making connection:  378 --> 373
+Processing reward:  Mt. Kolts
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Bahamut !
+	Updated Rewards Obtained:  2 Characters,  3 Espers
+	Updated Rewards Available:  4 Characters,  6 Espers
+	Updated branch checks available:
+	 0 :  []
+	 1 :  ['Zozo', 'Mt. Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, True, True] Stuck: {2}
+Working on branch 1 ( ['Zozo', 'Mt. Zozo'] )
+status: terminus ruin_terminus_1
+status: check rooms [313, 256]
+status: dead ends ['ruin_terminus_1', 'branch-mz_mapsafe', 310, 313, '306r', 256, 251, 147, 149, 157]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 27 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 372 in room 151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 15 connections, selected: 390 in room 160
+Looking for reward in room 160 ...
+Making connection:  372 --> 390
+	Active room:  160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 25 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 366 in room 160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 13 connections, selected: 381 in room 155
+Looking for reward in room 155 ...
+Making connection:  366 --> 381
+	Active room:  155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 23 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 385 in room 155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 11 connections, selected: 389 in room 159
+Looking for reward in room 159 ...
+Making connection:  385 --> 389
+	Active room:  159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 20 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 374 in room 159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 8 connections, selected: 363 in room 145
+Looking for reward in room 145 ...
+Making connection:  374 --> 363
+	Active room:  145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 18 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 382 in room 145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 6 connections, selected: 383 in room 156
+Looking for reward in room 156 ...
+Making connection:  382 --> 383
+	Active room:  156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 16 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 387 in room 156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 4 connections, selected: 371 in room 150
+Looking for reward in room 150 ...
+Making connection:  387 --> 371
+	Active room:  150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 14 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 391 in room 150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 2 connections, selected: 1176 in room 148
+Looking for reward in room 148 ...
+Making connection:  391 --> 1176
+	Active room:  148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 12 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 1179 in room 148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 12 connections, selected: 367 in room 147
+Looking for reward in room 147 ...
+Making connection:  1179 --> 367
+	Active room:  147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 11 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 370 in room 147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 11 connections, selected: 626 in room 303b
+Looking for reward in room 303b ...
+Making connection:  370 --> 626
+		assessing key  clock3 in rooms
+			removing key  clock3 from 303a
+			removing key  clock3 from 303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Active room:  303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 9 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 368 in room 303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 9 connections, selected: 30537 in room branch-mz_mapsafe
+Looking for reward in room branch-mz_mapsafe ...
+Making connection:  368 --> 30537
+	Active room:  branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 8 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 384 in room branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Expanding search to all unconnected rooms...
+	Found 8 connections, selected: 1204 in room 256
+Looking for reward in room 256 ...
+Found a reward!  [('Mt. Zozo', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 256
+Making connection:  384 --> 1204
+Processing reward:  Mt. Zozo
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Golem !
+	Updated Rewards Obtained:  2 Characters,  4 Espers
+	Updated Rewards Available:  3 Characters,  5 Espers
+	Updated branch checks available:
+	 0 :  []
+	 1 :  ['Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, False, True] Stuck: {2}
+Adding reserve area PhantomTrain (22 rooms) to unstick branch 1
+	Added new check: Phantom Train
+	trimmed dead end  branch-mz_mapsafe
+	trimmed dead end  256
+	trimmed dead end  147
+Working on branch 1 ( ['Zozo', 'Phantom Train'] )
+status: terminus ruin_terminus_1
+status: check rooms [313, 220]
+status: dead ends ['ruin_terminus_1', 310, 313, '306r', 251, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221]
+Forcing connections...
+Forcing:  2067 3067
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 53 doors, 3 pits
+	Total doors in connected path: 2
+	Trying door exit: 1175 in room 256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+		Filtered out path doors (path has only 2 doors)
+	Found 34 connections, selected: 473 in room 202
+Looking for reward in room 202 ...
+Making connection:  1175 --> 473
+	Active room:  202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 8 doors, 0 traps
+	Available entrances: 44 doors, 3 pits
+	Total doors in connected path: 9
+	Trying door exit: 472 in room 202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 25 connections, selected: 1541 in room 207
+Looking for reward in room 207 ...
+Making connection:  472 --> 1541
+	Active room:  207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 10 doors, 0 traps
+	Available entrances: 40 doors, 3 pits
+	Total doors in connected path: 11
+	Trying door exit: 1532 in room 207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 21 connections, selected: 501 in room 220
+Looking for reward in room 220 ...
+Found a reward!  [('Phantom Train', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 220
+Making connection:  1532 --> 501
+Processing reward:  Phantom Train
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Shiva !
+	Updated Rewards Obtained:  2 Characters,  5 Espers
+	Updated Rewards Available:  2 Characters,  4 Espers
+	Updated branch checks available:
+	 0 :  []
+	 1 :  ['Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, True, True] Stuck: {2}
+Working on branch 1 ( ['Zozo'] )
+status: terminus ruin_terminus_1
+status: check rooms [313]
+status: dead ends ['ruin_terminus_1', 310, 313, '306r', 251, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 12 doors, 0 traps
+	Available entrances: 36 doors, 3 pits
+	Total doors in connected path: 13
+	Trying door exit: 1529 in room 220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 17 connections, selected: 474 in room 204
+Looking for reward in room 204 ...
+Making connection:  1529 --> 474
+	Active room:  204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 32 doors, 3 pits
+	Total doors in connected path: 15
+	Trying door exit: 1539 in room 204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 13 connections, selected: 1516 in room 203a
+Looking for reward in room 203a ...
+Making connection:  1539 --> 1516
+	Active room:  203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 30 doors, 2 pits
+	Total doors in connected path: 15
+	Trying door exit: 1540 in room 203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+	Found 11 connections, selected: 1521 in room 204c
+Looking for reward in room 204c ...
+Making connection:  1540 --> 1521
+	Active room:  204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  [205]
+	Available exits: 1 doors, 0 traps
+	Available entrances: 27 doors, 2 pits
+	Total doors in connected path: 16
+	Trying door exit: 1525 in room 205
+	Found 24 connections, selected: 471 in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r
+Looking for reward in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r ...
+Making connection:  1525 --> 471
+	Active room:  204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 1 traps
+	Available entrances: 27 doors, 2 pits
+	Total doors in connected path: 14
+	Trying trap exit: 2066 in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205
+	Found 2 connections, selected: 3068 in room ruin-201
+Looking for reward in room ruin-201 ...
+Making connection:  2066 --> 3068
+	Active room:  ruin-201 .
+	Upstream nodes:  ['204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205', '303a'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 1 traps
+	Available entrances: 26 doors, 1 pits
+	Total doors in connected path: 15
+	Trying trap exit: 2065 in room ruin-201
+	Found 2 connections, selected: 3065 in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205
+Looking for reward in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205 ...
+Making connection:  2065 --> 3065
+	Active room:  204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 26 doors, 1 pits
+	Total doors in connected path: 15
+	Trying door exit: 1522 in room 204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+	Found 8 connections, selected: 1520 in room 204b
+Looking for reward in room 204b ...
+Making connection:  1522 --> 1520
+	Active room:  204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 24 doors, 1 pits
+	Total doors in connected path: 15
+	Trying door exit: 500 in room 204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+	Found 6 connections, selected: 1536 in room 206
+Looking for reward in room 206 ...
+Making connection:  500 --> 1536
+	Active room:  206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 20 doors, 1 pits
+	Total doors in connected path: 17
+	Trying door exit: 1535 in room 206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+	Found 2 connections, selected: 1524 in room 203b
+Looking for reward in room 203b ...
+Making connection:  1535 --> 1524
+	Active room:  203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 18 doors, 0 pits
+	Total doors in connected path: 17
+	Trying door exit: 496 in room 203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 18 connections, selected: 1543 in room 207a
+Looking for reward in room 207a ...
+Making connection:  496 --> 1543
+	Active room:  207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 17 doors, 0 pits
+	Total doors in connected path: 16
+	Trying door exit: 1531 in room 207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 17 connections, selected: 534 in room 251
+Looking for reward in room 251 ...
+Making connection:  1531 --> 534
+	Active room:  251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 16 doors, 0 pits
+	Total doors in connected path: 15
+	Trying door exit: 1519 in room 251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 16 connections, selected: 491 in room 215b
+Looking for reward in room 215b ...
+Making connection:  1519 --> 491
+	Active room:  215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 15 doors, 0 pits
+	Total doors in connected path: 14
+	Trying door exit: 1528 in room 215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 15 connections, selected: 4630 in room 306r
+Looking for reward in room 306r ...
+Making connection:  1528 --> 4630
+		assessing key  clock2 in rooms
+			removing key  clock2 from 306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+	Active room:  306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 12 doors, 0 traps
+	Available entrances: 14 doors, 0 pits
+	Total doors in connected path: 13
+	Trying door exit: 475 in room 306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 14 connections, selected: 502 in room 221
+Looking for reward in room 221 ...
+Making connection:  475 --> 502
+	Active room:  221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 11 doors, 0 traps
+	Available entrances: 13 doors, 0 pits
+	Total doors in connected path: 12
+	Trying door exit: 476 in room 221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 13 connections, selected: 1538 in room 206b
+Looking for reward in room 206b ...
+Making connection:  476 --> 1538
+	Active room:  206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 10 doors, 0 traps
+	Available entrances: 12 doors, 0 pits
+	Total doors in connected path: 11
+	Trying door exit: 1530 in room 206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 12 connections, selected: 1079 in room ruin_terminus_1
+Looking for reward in room ruin_terminus_1 ...
+Making connection:  1530 --> 1079
+	Active room:  ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 9 doors, 0 traps
+	Available entrances: 11 doors, 0 pits
+	Total doors in connected path: 10
+	Trying door exit: 1533 in room ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 11 connections, selected: 634 in room 310
+Looking for reward in room 310 ...
+Making connection:  1533 --> 634
+	Active room:  310_ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 .
+	Upstream nodes:  ['303a'] 
+	Downstream nodes:  []
+	Available exits: 8 doors, 0 traps
+	Available entrances: 10 doors, 0 pits
+	Total doors in connected path: 9
+	Trying door exit: 1515 in room 310_ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+		Expanding search to all unconnected rooms...
+	Found 10 connections, selected: 1225 in room 313
+Looking for reward in room 313 ...
+Found a reward!  [('Zozo', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 313
+Making connection:  1515 --> 1225
+Processing reward:  Zozo
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got STRAGO !
+	Set character path: STRAGO depends on TERRA
+		assessing key  STRAGO in rooms
+		assessing key  STRAGO in rooms
+		assessing key  STRAGO in rooms
+		# rooms on each branch:  [29, 90, 54]
+		# rooms on each branch:  [30, 90, 54]
+Forced same branch: EbotsRock Thamasa 0
+Distributed areas:
+	 0 :  {'FanaticsTower', 'EbotsRock', 'Thamasa'}
+	 1 :  set()
+	 2 :  set()
+Checks available:
+	 0 :  ["Fanatic's Tower", "Ebot's Rock"]
+	 1 :  ['Zozo']
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	Updated Rewards Obtained:  3 Characters,  5 Espers
+	Updated Rewards Available:  3 Characters,  5 Espers
+	Updated branch checks available:
+	 0 :  ["Fanatic's Tower", "Ebot's Rock"]
+	 1 :  []
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, True, True] Stuck: {2}
+	trimmed dead end  ms-wor-52
+	trimmed dead end  363
+Working on branch 0 ( ["Fanatic's Tower", "Ebot's Rock"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-78', 'ms-wor-69']
+status: dead ends ['ruin_terminus_2', 41, 47, 'ms-wor-78', 'ms-wor-69']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 7 doors, 1 pits
+	Total doors in connected path: 5
+	Trying door exit: 1147 in room 363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+	Found 2 connections, selected: 1260 in room ruin-thamasa
+Looking for reward in room ruin-thamasa ...
+Making connection:  1147 --> 1260
+	Active room:  ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 5 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 150 in room ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+	Found 5 connections, selected: 1150 in room 41
+Looking for reward in room 41 ...
+Making connection:  150 --> 1150
+	Active room:  41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 1261 in room 41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+	Found 4 connections, selected: 1546 in room ms-wor-78
+Looking for reward in room ms-wor-78 ...
+Found a reward!  [("Ebot's Rock", <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room ms-wor-78
+Making connection:  1261 --> 1546
+Processing reward:  Ebot's Rock
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Palidor !
+	Updated Rewards Obtained:  3 Characters,  6 Espers
+	Updated Rewards Available:  2 Characters,  4 Espers
+	Updated branch checks available:
+	 0 :  ["Fanatic's Tower"]
+	 1 :  []
+	 2 :  ['South Figaro Cave', 'Serpent Trench', 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+Branch viability: [True, True, True] Stuck: {2}
+	trimmed dead end  41
+	trimmed dead end  ms-wor-78
+Working on branch 0 ( ["Fanatic's Tower"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69']
+status: dead ends ['ruin_terminus_2', 47, 'ms-wor-69']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 3 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 140 in room ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+	Found 3 connections, selected: 1057 in room ruin_terminus_2
+Looking for reward in room ruin_terminus_2 ...
+Making connection:  140 --> 1057
+	Active room:  ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 2 doors, 0 pits
+	Total doors in connected path: 2
+	Trying door exit: 719 in room ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		Expanding search to all unconnected rooms...
+		Filtered out path doors (path has only 2 doors)
+	Found 2 connections, selected: 158 in room 47
+Looking for reward in room 47 ...
+Making connection:  719 --> 158
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 1 doors, 0 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 1 doors, 0 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 1 doors, 0 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [False, True, True] Stuck: {0, 2}
+Adding reserve area EsperMountain (13 rooms) to unstick branch 0
+	Added new check: Esper Mountain
+	trimmed dead end  ruin_terminus_2
+	trimmed dead end  47
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488]
+status: dead ends ['ms-wor-69', 490, 493, 494]
+Forcing connections...
+Forcing:  2011 3011
+forcing successful.
+Forcing:  2012 3012
+forcing successful.
+Forcing:  2013 3013
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 23 doors, 3 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 23 doors, 3 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 23 doors, 3 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area Vector (12 rooms) to unstick branch 0
+	Added new check: Magitek Factory_1
+	Added new check: Magitek Factory_2
+	Added new check: Magitek Factory_3
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352]
+Forcing connections...
+Forcing:  2023 3023
+forcing successful.
+Forcing:  2128 3128
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 38 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 38 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 38 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area DarylsTomb (16 rooms) to unstick branch 0
+	Added new check: Daryl's Tomb
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392]
+Forcing connections...
+Forcing:  2059 3059
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 65 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 65 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 65 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area AncientCastle (13 rooms) to unstick branch 0
+	Added new check: Ancient Castle
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532]
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 95 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 95 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 95 doors, 9 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area VeldtCave (9 rooms) to unstick branch 0
+	Added new check: Veldt Cave WOR
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475]
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 111 doors, 10 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 111 doors, 10 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 111 doors, 10 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area Jidoor (9 rooms) to unstick branch 0
+	Added new check: Auction House_1
+	Added new check: Auction House_2
+	Added new check: Owzer Mansion
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284]
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 124 doors, 14 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 124 doors, 14 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 124 doors, 14 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area UmarosCave (9 rooms) to unstick branch 0
+	Added new check: Umaro's Cave
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368]
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284]
+Forcing connections...
+Forcing:  2005 3005
+forcing successful.
+Forcing:  2006 3006
+forcing successful.
+Forcing:  2007 3007
+forcing successful.
+Forcing:  2008 3008
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 134 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 134 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 134 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area BarenFalls (3 rooms) to unstick branch 0
+	Added new check: Baren Falls
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284]
+Forcing connections...
+Forcing:  2076 3076
+forcing successful.
+Forcing:  2176 3176
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 136 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 136 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 136 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area ImperialCamp (1 rooms) to unstick branch 0
+	Added new check: Imperial Camp
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 138 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 138 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 138 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area FigaroCastle (1 rooms) to unstick branch 0
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 139 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 139 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 139 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area SouthFigaro (1 rooms) to unstick branch 0
+	Added new check: South Figaro
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 141 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 141 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 141 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area ImperialCastle (1 rooms) to unstick branch 0
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 149 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 149 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 149 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area Tzen (1 rooms) to unstick branch 0
+	Added new check: Tzen
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 150 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 150 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 150 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area GauFatherHouse (1 rooms) to unstick branch 0
+	Added new check: Gau Father House
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen', 'Gau Father House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51', 'ms-wob-14']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51', 'ms-wob-14']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 151 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 151 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 151 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area FloatingContinent (1 rooms) to unstick branch 0
+	Added new check: Floating Continent_1
+	Added new check: Floating Continent_2
+	Added new check: Floating Continent_3
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen', 'Gau Father House', 'Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 152 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 152 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 152 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area OperaHouse (1 rooms) to unstick branch 0
+	Added new check: Opera House
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen', 'Gau Father House', 'Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 153 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 153 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 153 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding reserve area Cid (1 rooms) to unstick branch 0
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen', 'Gau Father House', 'Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40', 'ms-wor-48']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+Adding extra area ImperialCastle to unstick branch 0
+	Skipping room 331 - already exists
+Working on branch 0 ( ["Fanatic's Tower", 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", 'Ancient Castle', 'Veldt Cave WOR', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', "Umaro's Cave", 'Baren Falls', 'Imperial Camp', 'South Figaro', 'Tzen', 'Gau Father House', 'Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wor-69', 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 532, 475, 'dc-73', 284, 368, 'ruin-baren-reward', 'dc-1501', 'ms-wor-58', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40']
+status: dead ends ['ms-wor-69', 490, 493, 494, 352, 380, 384, 386, 389, 392, 525, 526, 527, 532, 468, 279, 284, 'ruin-figarocastle', 'ms-wor-51', 'ms-wob-14', 'ms-wob-1556', 'ms-wob-40', 'ms-wor-48']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 1/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 failed to extend, retry 2/3
+	Active room:  47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 154 doors, 21 pits
+	Total doors in connected path: 1
+		Filtering exit 717 - would strand pits in 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b
+		No safe door exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, True] Stuck: {0, 2}
+ERROR: No reserve areas available to unstick branches!
+Closing branch...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	hub: 47_ruin_terminus_2_ms-wor-78_41_ruin-thamasa_363_ms-wor-52_65_358_356_357_359_45_361_42_36_50_37a_359b_ruin-narshe_ms-wor-63_362_ruin-whelk_ruin_hub_0_38_43_40_49_51_44_358b [1, 0, 3, 0, 1]
+	pits: [3009, 3075, 3055]
+	traps: []
+(2) delta values: []
+(4) remaining doors: [717]
+(4) terminus already merged into hub, skipping
+(6) remaining dead ends: [493, 'ms-wob-40', 386, 'ms-wob-14', 'ms-wor-48', 384, 352, 380, 284, 392, 468, 526, 'ruin-figarocastle', 527, 532, 279, 'ms-wor-51', 494, 'ms-wob-1556', 'ms-wor-69', 525, 389, 490]
+(6) connecting dead ends: 717 --> 1037
+... closing branch complete!
+Closing branch...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	hub: 313_310_ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201 [7, 0, 1, 0, 1]
+	pits: [3066]
+	traps: []
+(2) delta values: []
+(4) remaining doors: [1523, 469, 1542, 1518, 470, 497, 1534]
+(4) terminus already merged into hub, skipping
+(6) remaining dead ends: ['206a', '203c', '207b', 212, '215a', 149, 157, 213]
+(6) connecting dead ends: 1523 --> 488
+(6) connecting dead ends: 469 --> 386
+(6) connecting dead ends: 1542 --> 369
+(6) connecting dead ends: 1518 --> 489
+(6) connecting dead ends: 470 --> 1545
+		assessing key  pt2 in rooms
+			Applying key: ('pt2',) in room 212_215a_149_157_213_313_310_ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+			adding a trap... 2068
+			removing key  pt2 from 212_215a_149_157_213_313_310_ruin_terminus_1_206b_221_306r_215b_251_207a_203b_206_204b_204c_203a_204_220_207_202_256_branch-mz_mapsafe_303b_147_148_150_156_145_159_155_160_151_152_146_154_153_158_wor-veldt_305r_root-mz_mapsafe_511_295r_309r_294r_504_513_308r_312_302_254_255_250_253_252_512_LeteRiver2_ruin-returners_304_299_300_LeteCave2_LeteCave1_507_296r_ruin-zozo_297_298_503_508_510_509_301r_502_506_ruin_hub_1_311_505_LeteRiver3_LeteRiver1_307r_205_ruin-201
+(6) connecting dead ends: 497 --> 1544
+(6) connecting dead ends: 1534 --> 1514
+... closing branch complete!
+Closing branch...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	hub: 430_188_ruin_hub_2 [5, 0, 1, 0, 0]
+	pits: [6862, 6848, 6845, 6849, 6843]
+	traps: [843, 852]
+(2) delta values: [(1, 428), (0, 421), (1, '425_102_247a')]
+(2) selected 425_102_247a (delta =  1 ):  [0, 1, 2, 0, 0] [] [852] [6849, 6843]
+(2) connecting 852 --> 6862
+(2) delta values: []
+(4) remaining doors: [451, 440, 445, 441, 449]
+(4) connecting terminus: 449 --> 1564
+(6) remaining dead ends: [190, '221R', 185, 184, 103, 426, 192, 'ms-wor-1554', 189]
+(6) connecting dead ends: 451 --> 442
+(6) connecting dead ends: 440 --> 1555
+(6) connecting dead ends: 445 --> 455
+(6) connecting dead ends: 441 --> 851
+... closing branch complete!
+Gau not in planned characters, all accessible shops valid for dried meat
+REWARD STATE AFTER RUIN MAPPING:
+Magitek Factory None None
+Doma WOR None None
+Figaro Castle WOR None None
+Narshe Battle None None
+Auction House None None
+Daryl's Tomb None None
+Opera House None None
+South Figaro None None
+Magitek Factory None None
+Phoenix Cave None None
+Doma WOR None None
+Kefka's Tower None None
+Burning House None None
+Tzen None None
+Owzer Mansion None None
+South Figaro Cave None None
+Veldt 4 RewardType.ESPER
+Imperial Camp None None
+Ancient Castle None None
+Serpent Trench None None
+Umaro's Cave None None
+Floating Continent None None
+Kohlingen None None
+Doom Gaze None None
+Lete River 2 RewardType.CHARACTER
+Phantom Train 2 RewardType.ESPER
+Veldt Cave WOR None None
+Doma WOB None None
+Auction House None None
+Floating Continent None None
+Mt. Kolts 13 RewardType.ESPER
+Baren Falls None None
+Mobliz WOR None None
+Lone Wolf None None
+Fanatic's Tower None None
+Zozo 7 RewardType.CHARACTER
+8 Dragons None None
+8 Dragons None None
+Mt. Zozo 22 RewardType.ESPER
+Zone Eater 18 RewardType.ESPER
+Figaro Castle WOB None None
+8 Dragons None None
+Doma WOR None None
+Lone Wolf None None
+Magitek Factory None None
+Fanatic's Tower None None
+8 Dragons None None
+Narshe WOR None None
+Tritoch None None
+Esper Mountain None None
+8 Dragons None None
+8 Dragons None None
+Narshe WOR None None
+Whelk 12 RewardType.CHARACTER
+8 Dragons None None
+Floating Continent None None
+Narshe Moogle Defense None None
+Gau Father House None None
+8 Dragons None None
+Collapsing House None None
+Ebot's Rock 9 RewardType.ESPER
+Sealed Gate None None
+REWARD STATE FINAL:
+Figaro Castle WOR 13 RewardType.CHARACTER
+Narshe Battle 1 RewardType.ESPER
+Daryl's Tomb 9 RewardType.CHARACTER
+Opera House 8 RewardType.CHARACTER
+South Figaro 3 RewardType.CHARACTER
+Magitek Factory 7 RewardType.ESPER
+Phoenix Cave 10 RewardType.CHARACTER
+Doma WOR 16 RewardType.ESPER
+Burning House 17 RewardType.ESPER
+Tzen 3 RewardType.ESPER
+Owzer Mansion 11 RewardType.ESPER
+South Figaro Cave 25 RewardType.ESPER
+Imperial Camp 26 RewardType.ESPER
+Ancient Castle 0 RewardType.ESPER
+Serpent Trench 8 RewardType.ESPER
+Umaro's Cave 10 RewardType.ESPER
+Kohlingen 24 RewardType.ESPER
+Doom Gaze 15 RewardType.ESPER
+Veldt Cave WOR 20 RewardType.ESPER
+Doma WOB 6 RewardType.ESPER
+Auction House 19 RewardType.ESPER
+Baren Falls 14 RewardType.ESPER
+Mobliz WOR 21 RewardType.ESPER
+Figaro Castle WOB 5 RewardType.ESPER
+Doma WOR 97 RewardType.ITEM
+Lone Wolf 27 RewardType.ITEM
+Magitek Factory 26 RewardType.ITEM
+Tritoch 104 RewardType.ITEM
+Esper Mountain 148 RewardType.ITEM
+Narshe WOR 228 RewardType.ITEM
+Floating Continent 96 RewardType.ITEM
+Narshe Moogle Defense 27 RewardType.ITEM
+Gau Father House 97 RewardType.ITEM
+Collapsing House 228 RewardType.ITEM
+Sealed Gate 209 RewardType.ITEM
+
+
+Traceback (most recent call last):
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\wc.py", line 58, in <module>
+    main()
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\wc.py", line 12, in main
+    events = Events(memory.rom, args, data)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 25, in __init__
+    events = self.mod()
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 74, in mod
+    self.ruination_mod(events, name_event)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 283, in ruination_mod
+    disable_chocobo_stables(self.rom, self.dialogs)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\ruination.py", line 2278, in disable_chocobo_stables
+    if args.debug:
+NameError: name 'args' is not defined

--- a/event/events.py
+++ b/event/events.py
@@ -280,7 +280,7 @@ class Events():
         modify_inn_costs(self.maps, self.rom, self.dialogs, self.args)
 
         # Disable in-town chocobo stables for ruination mode
-        disable_chocobo_stables(self.rom, self.dialogs)
+        disable_chocobo_stables(self.rom, self.dialogs, self.args)
 
         # Modify existing free bed heals (HP-only heal with 3/8 monster attack chance)
         modify_free_bed_heals(self.maps, self.rom)

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -2246,7 +2246,7 @@ def modify_inn_costs(maps, rom, dialogs, args):
         print(f"Warning: Could not find Figaro Castle rest event at (47, 52)")
 
 
-def disable_chocobo_stables(rom, dialogs):
+def disable_chocobo_stables(rom, dialogs, args):
     """
     Disables the in-town chocobo stables for ruination mode.
     Changes the chocobo keeper dialogs to explain chocobos won't go outside,
@@ -2255,6 +2255,7 @@ def disable_chocobo_stables(rom, dialogs):
     Args:
         rom: The ROM object to modify
         dialogs: The Dialogs object to update dialog text
+        args: Command line arguments (for debug flag)
     """
     # Chocobo stable event addresses and their dialog IDs
     # Format: (event_address, dialog_id, description)


### PR DESCRIPTION
The function referenced args.debug but args was not passed as a parameter. Added args to the function signature and updated the call site in events.py to pass self.args.