### PR TITLE
Fix finalize_map using room IDs instead of element IDs for converter …

### DIFF
--- a/claude_reference/output_260119_1732.txt
+++ b/claude_reference/output_260119_1732.txt
@@ -1,0 +1,2065 @@
+Version   1.4.2
+Generated 2026-01-19 17:31:58
+Input     FFIII.smc
+Output    ruin.smc
+Log       ruin.txt
+Seed      kz1huh8abws1
+Flags     -oa 2.2.2.2.6.6.4.9.9 -sc1 random -sc2 random -sc3 random -sal -eu -csrp 80 125 -fst -brl -slr 3 5 -lmprp 75 125 -lel -srr 25 35 -rnl -rnc -sdr 1 2 -das -dda -dns -sch -scis -com 98989898989898989898989898 -rec1 28 -rec2 27 -xpm 3 -mpm 5 -gpm 0 -nxppd -lsced 2 -hmced 2 -xgced 2 -ase 2 -msl 40 -sed -bbs -drloc shuffle -stloc mix -be -bnu -res -fer 0 -escr 100 -dgne -wnz -mmnu -cmd -esr 2 5 -elrt -ebr 82 -emprp 75 125 -nm1 random -rnl1 -rns1 -nm2 random -rnl2 -rns2 -nmmi -mmprp 75 125 -gp 5000 -smc 3 -sto 1 -ieor 33 -ieror 33 -ir stronger -csb 6 14 -mca -stra -saw -sisr 20 -sprp 75 125 -sdm 4 -npi -sebr -snsb -snee -snil -ccsr 20 -chrm 5 0 -cms -frw -wmhc -cor 100 -crr 100 -crvr 100 120 -crm -ari -anca -adeh -ame 1 -nmc -noshoes -u254 -nfps -fs -fe -fvd -fr -fj -fbs -fedc -fc -ond -etn -ruin
+Hash      Man, Gestahl, Dancer, Sigfried
+Requested:  6 characters,  9 espers
+Pre-plan: Planned areas have 17 checks, 14 character slots, 17 esper slots
+Pre-plan: Will obtain characters: ['STRAGO', 'MOG', 'CYAN']
+Pre-plan: Reserve characters (for extra areas): ['GAU', 'SABIN', 'UMARO', 'CELES', 'LOCKE', 'GOGO', 'SETZER', 'RELM']
+Pre-plan: Dead checks allowed: 5
+Areas used:  {'SealedGate', 'ZozoTower', 'Narshe', 'AncientCastle', 'FloatingContinent', 'Zozo', 'GauFatherHouse', 'Thamasa', 'Mobliz', 'SouthFigaro', 'VeldtCave', 'ReturnersHideout', 'FigaroCastle'}
+Forced same branch: Zozo ZozoTower 0
+Forced same branch: VeldtCave Thamasa 2
+Distributed areas:
+	 0 :  {'ZozoTower', 'AncientCastle', 'Zozo', 'GauFatherHouse', 'ReturnersHideout'}
+	 1 :  {'SealedGate', 'FloatingContinent', 'FigaroCastle', 'SouthFigaro'}
+	 2 :  {'VeldtCave', 'Narshe', 'Thamasa', 'Mobliz'}
+Checks available:
+	 0 :  ['Lete River', 'Zozo', 'Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3']
+	 2 :  ['Whelk', 'Veldt Cave WOR']
+CUSTOM add pit 3039 to ruin_hub_0 ! [1, 0, 1, 0, 0] [3039]
+Rewards available:  [8, 9]
+		assessing key  TERRA in rooms
+			Applying key: ('TERRA',) in room ruin-zozo
+			adding a door... 608
+		assessing key  SHADOW in rooms
+		assessing key  EDGAR in rooms
+		assessing key  TERRA in rooms
+		assessing key  SHADOW in rooms
+		assessing key  EDGAR in rooms
+		assessing key  TERRA in rooms
+			Applying key: ('TERRA',) in room ruin-whelk
+			adding a door... 1155
+		assessing key  SHADOW in rooms
+		assessing key  EDGAR in rooms
+Generating map with characters...
+Branch viability: [True, True, True] Stuck: set()
+Working on branch 1 ( ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3'] )
+status: terminus ruin_terminus_3
+status: check rooms ['ms-wob-1556', 'ms-wor-58']
+status: dead ends ['ruin_hub_1', 'ruin_terminus_3', 513, 'ruin-figarocastle', 'ms-wob-1556', 504, 511]
+Forcing connections...
+Forcing:  2029 3029
+forcing successful.
+Forcing:  2030 3030
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 25 doors, 1 pits
+	Total doors in connected path: 1
+	Trying door exit: 394 in room ruin_hub_1
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 17 connections, selected: 1072 in room 509
+Looking for reward in room 509 ...
+Making connection:  394 --> 1072
+	Active room:  509_ruin_hub_1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  [510, 508]
+	Available exits: 1 doors, 0 traps
+	Available entrances: 21 doors, 1 pits
+	Total doors in connected path: 3
+	Trying door exit: 1070 in room 508
+	Found 15 connections, selected: 1075 in room 512
+Looking for reward in room 512 ...
+Making connection:  1070 --> 1075
+	Active room:  512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 19 doors, 1 pits
+	Total doors in connected path: 3
+	Trying door exit: 1077 in room 512_508
+	Found 13 connections, selected: 1163 in room ms-wor-58
+Looking for reward in room ms-wor-58 ...
+Found a reward!  [('South Figaro', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room ms-wor-58
+		reward is locked by CELES . Saving for later.
+Making connection:  1077 --> 1163
+	Active room:  ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 17 doors, 1 pits
+	Total doors in connected path: 3
+	Trying door exit: 1162 in room ms-wor-58_512_508
+	Found 11 connections, selected: 1067 in room 506
+Looking for reward in room 506 ...
+Making connection:  1162 --> 1067
+	Active room:  506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 15 doors, 1 pits
+	Total doors in connected path: 3
+	Trying door exit: 1066 in room 506_ms-wor-58_512_508
+	Found 9 connections, selected: 1059 in room 502
+Looking for reward in room 502 ...
+Making connection:  1066 --> 1059
+	Active room:  502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 12 doors, 1 pits
+	Total doors in connected path: 4
+	Trying door exit: 1263 in room 502_506_ms-wor-58_512_508
+	Found 6 connections, selected: 1065 in room 505
+Looking for reward in room 505 ...
+Making connection:  1263 --> 1065
+	Active room:  505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 10 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 1064 in room 505_502_506_ms-wor-58_512_508
+	Found 4 connections, selected: 1062 in room 503
+Looking for reward in room 503 ...
+Making connection:  1064 --> 1062
+	Active room:  503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 8 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 1061 in room 503_505_502_506_ms-wor-58_512_508
+	Found 2 connections, selected: 1069 in room 507
+Looking for reward in room 507 ...
+Making connection:  1061 --> 1069
+	Active room:  507_503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 1 traps
+	Available entrances: 6 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 1058 in room 507_503_505_502_506_ms-wor-58_512_508
+		Expanding search to all unconnected rooms...
+	Found 6 connections, selected: 1564 in room ruin_terminus_3
+Looking for reward in room ruin_terminus_3 ...
+Making connection:  1058 --> 1564
+	Active room:  ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 1 traps
+	Available entrances: 5 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 1264 in room ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508
+		Expanding search to all unconnected rooms...
+	Found 5 connections, selected: 1156 in room ruin-figarocastle
+Looking for reward in room ruin-figarocastle ...
+Making connection:  1264 --> 1156
+	Active room:  ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 2
+		Filtering exit 2031 - would strand pits in ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 1 failed to extend, retry 1/3
+	Active room:  ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 2
+		Filtering exit 2031 - would strand pits in ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 1 failed to extend, retry 2/3
+	Active room:  ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508 .
+	Upstream nodes:  [510, '509_ruin_hub_1'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 2
+		Filtering exit 2031 - would strand pits in ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 1 is stuck after 3 retries
+Skipping reward processing for stuck branch 1
+Branch viability: [True, False, True] Stuck: {1}
+Working on branch 2 ( ['Whelk', 'Veldt Cave WOR'] )
+status: terminus ruin_terminus_1
+status: check rooms [65, 475, 'ruin-whelk']
+status: dead ends ['ruin_hub_2', 'ruin_terminus_1', 41, 47, 468, 'ms-wor-52']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 53 doors, 2 pits
+	Total doors in connected path: 1
+	Trying door exit: 395 in room ruin_hub_2
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 46 connections, selected: 981 in room 469
+Looking for reward in room 469 ...
+Making connection:  395 --> 981
+	Active room:  469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 51 doors, 2 pits
+	Total doors in connected path: 1
+	Trying door exit: 986 in room 469_ruin_hub_2
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 44 connections, selected: 162 in room 49
+Looking for reward in room 49 ...
+Making connection:  986 --> 162
+	Active room:  49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 47 doors, 2 pits
+	Total doors in connected path: 3
+	Trying door exit: 161 in room 49_469_ruin_hub_2
+	Found 41 connections, selected: 149 in room 42
+Looking for reward in room 42 ...
+Making connection:  161 --> 149
+	Active room:  42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 45 doors, 2 pits
+	Total doors in connected path: 3
+	Trying door exit: 164 in room 42_49_469_ruin_hub_2
+	Found 39 connections, selected: 990 in room 474
+Looking for reward in room 474 ...
+Making connection:  164 --> 990
+	Active room:  474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 43 doors, 2 pits
+	Total doors in connected path: 3
+	Trying door exit: 163 in room 474_42_49_469_ruin_hub_2
+	Found 37 connections, selected: 140 in room ruin-narshe
+Looking for reward in room ruin-narshe ...
+Making connection:  163 --> 140
+	Active room:  ruin-narshe_474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 39 doors, 2 pits
+	Total doors in connected path: 5
+	Trying door exit: 1146 in room ruin-narshe_474_42_49_469_ruin_hub_2
+	Found 33 connections, selected: 985 in room 467
+Looking for reward in room 467 ...
+Making connection:  1146 --> 985
+	Active room:  467_ruin-narshe_474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 36 doors, 2 pits
+	Total doors in connected path: 6
+	Trying door exit: 143 in room 467_ruin-narshe_474_42_49_469_ruin_hub_2
+	Found 30 connections, selected: 1148 in room 40
+Looking for reward in room 40 ...
+Making connection:  143 --> 1148
+	Active room:  40_467_ruin-narshe_474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 34 doors, 2 pits
+	Total doors in connected path: 6
+	Trying door exit: 1149 in room 40_467_ruin-narshe_474_42_49_469_ruin_hub_2
+	Found 28 connections, selected: 984 in room 471
+Looking for reward in room 471 ...
+Making connection:  1149 --> 984
+	Active room:  471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 32 doors, 2 pits
+	Total doors in connected path: 6
+	Trying door exit: 148 in room 471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2
+	Found 26 connections, selected: 991 in room 475
+Looking for reward in room 475 ...
+Found a reward!  [('Veldt Cave WOR', <RewardType.ESPER|CHARACTER: 6>)] in room 475
+Making connection:  148 --> 991
+Processing reward:  Veldt Cave WOR
+	choosing from... RewardType.ESPER|CHARACTER
+	got Fenrir !
+	Updated Rewards Obtained:  0 Characters,  1 Espers
+	Updated Rewards Available:  7 Characters,  8 Espers
+	Updated branch checks available:
+	 0 :  ['Lete River', 'Zozo', 'Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3']
+	 2 :  ['Whelk']
+Branch viability: [True, False, True] Stuck: {1}
+Working on branch 0 ( ['Lete River', 'Zozo', 'Ancient Castle', 'Gau Father House'] )
+status: terminus ruin_terminus_2
+status: check rooms [532, 'LeteRiver3', 313, 'ms-wob-14']
+status: dead ends ['ruin_hub_0', 'ruin_terminus_2', '295r', 525, 526, 527, 532, '305r', 310, 312, 313, '294r', '309r', 'ms-wob-14', 'branch-mz_mapsafe', '306r']
+Forcing connections...
+Forcing:  2032 3032
+forcing successful.
+Forcing:  2033 3033
+forcing successful.
+Forcing:  2064 3064
+forcing successful.
+Forcing:  2039 3039
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin_hub_0 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 73 doors, 4 pits
+	Total doors in connected path: 1
+	Trying door exit: 393 in room ruin_hub_0
+		Filtered out path doors (path has only 1 doors)
+		Filtered to rooms with 2+ doors (path has only 1 door left)
+	Found 52 connections, selected: 608 in room ruin-zozo
+Looking for reward in room ruin-zozo ...
+Making connection:  393 --> 608
+	Active room:  ruin-zozo_ruin_hub_0 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 67 doors, 4 pits
+	Total doors in connected path: 5
+	Trying door exit: 4601 in room ruin-zozo_ruin_hub_0
+	Found 47 connections, selected: 1088 in room 521
+Looking for reward in room 521 ...
+Making connection:  4601 --> 1088
+	Active room:  521_ruin-zozo_ruin_hub_0 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 7 doors, 0 traps
+	Available entrances: 63 doors, 4 pits
+	Total doors in connected path: 7
+	Trying door exit: 1274 in room 521_ruin-zozo_ruin_hub_0
+	Found 43 connections, selected: 611 in room 298
+Looking for reward in room 298 ...
+Making connection:  1274 --> 611
+	Active room:  298_521_ruin-zozo_ruin_hub_0 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  [297]
+	Available exits: 2 doors, 0 traps
+	Available entrances: 58 doors, 4 pits
+	Total doors in connected path: 10
+	Trying door exit: 609 in room 297
+	Found 46 connections, selected: 623 in room 302
+Looking for reward in room 302 ...
+Making connection:  609 --> 623
+	Active room:  302_297 .
+	Upstream nodes:  ['298_521_ruin-zozo_ruin_hub_0', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 56 doors, 4 pits
+	Total doors in connected path: 10
+	Trying door exit: 624 in room 302_297
+	Found 44 connections, selected: 1087 in room 520
+Looking for reward in room 520 ...
+Making connection:  624 --> 1087
+	Active room:  520_302_297 .
+	Upstream nodes:  ['298_521_ruin-zozo_ruin_hub_0', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 52 doors, 4 pits
+	Total doors in connected path: 12
+	Trying door exit: 1085 in room 520_302_297
+	Found 40 connections, selected: 1098 in room 528
+Looking for reward in room 528 ...
+Making connection:  1085 --> 1098
+		assessing key  ac2 in rooms
+			Applying key: ('ac2',) in room 531
+			adding a door... 1106
+			removing key  ac2 from 528_520_302_297
+	Active room:  528_520_302_297 .
+	Upstream nodes:  ['298_521_ruin-zozo_ruin_hub_0', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 49 doors, 4 pits
+	Total doors in connected path: 14
+	Trying door exit: 1278 in room 528_520_302_297
+	Found 38 connections, selected: 1103 in room 530
+Looking for reward in room 530 ...
+Making connection:  1278 --> 1103
+	Active room:  530_528_520_302_297 .
+	Upstream nodes:  ['298_521_ruin-zozo_ruin_hub_0', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 9 doors, 0 traps
+	Available entrances: 44 doors, 4 pits
+	Total doors in connected path: 17
+	Trying door exit: 610 in room 530_528_520_302_297
+	Found 33 connections, selected: 617 in room 299
+Looking for reward in room 299 ...
+Making connection:  610 --> 617
+		assessing key  clock5 in rooms
+			removing key  clock5 from 299_530_528_520_302_297
+	Active room:  299_530_528_520_302_297 .
+	Upstream nodes:  ['298_521_ruin-zozo_ruin_hub_0', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 9 doors, 0 traps
+	Available entrances: 42 doors, 4 pits
+	Total doors in connected path: 17
+	Trying door exit: 613 in room 299_530_528_520_302_297
+	Found 31 connections, selected: 4600 in room 298_521_ruin-zozo_ruin_hub_0
+Looking for reward in room 298_521_ruin-zozo_ruin_hub_0 ...
+Making connection:  613 --> 4600
+	Active room:  298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 42 doors, 4 pits
+	Total doors in connected path: 15
+	Trying door exit: 1101 in room 298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 23 connections, selected: 627 in room 304
+Looking for reward in room 304 ...
+Making connection:  1101 --> 627
+		assessing key  clock4 in rooms
+			removing key  clock4 from 304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Active room:  304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 40 doors, 4 pits
+	Total doors in connected path: 15
+	Trying door exit: 616 in room 304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 21 connections, selected: 1275 in room 522
+Looking for reward in room 522 ...
+Making connection:  616 --> 1275
+	Active room:  522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 38 doors, 4 pits
+	Total doors in connected path: 15
+	Trying door exit: 628 in room 522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 19 connections, selected: 1093 in room 524
+Looking for reward in room 524 ...
+Making connection:  628 --> 1093
+	Active room:  524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 36 doors, 4 pits
+	Total doors in connected path: 15
+	Trying door exit: 1102 in room 524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 17 connections, selected: 635 in room 311
+Looking for reward in room 311 ...
+Making connection:  1102 --> 635
+	Active room:  311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 34 doors, 4 pits
+	Total doors in connected path: 15
+	Trying door exit: 4602 in room 311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 15 connections, selected: 4620 in room 301r
+Looking for reward in room 301r ...
+Making connection:  4602 --> 4620
+		assessing key  clock1 in rooms
+			removing key  clock1 from 301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Active room:  301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 31 doors, 4 pits
+	Total doors in connected path: 16
+	Trying door exit: 1084 in room 301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 12 connections, selected: 1090 in room 523
+Looking for reward in room 523 ...
+Making connection:  1084 --> 1090
+	Active room:  523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 29 doors, 4 pits
+	Total doors in connected path: 16
+	Trying door exit: 1086 in room 523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 10 connections, selected: 619 in room 300
+Looking for reward in room 300 ...
+Making connection:  1086 --> 619
+	Active room:  300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 26 doors, 4 pits
+	Total doors in connected path: 17
+	Trying door exit: 614 in room 300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 7 connections, selected: 399 in room ruin-returners
+Looking for reward in room ruin-returners ...
+Making connection:  614 --> 399
+	Active room:  ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297 .
+	Upstream nodes:  ['LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 1 traps
+	Available entrances: 25 doors, 4 pits
+	Total doors in connected path: 16
+	Trying trap exit: 2034 in room ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297
+	Found 4 connections, selected: 3035 in room LeteCave1
+Looking for reward in room LeteCave1 ...
+Making connection:  2034 --> 3035
+	Active room:  LeteCave1 .
+	Upstream nodes:  ['ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297', 'LeteRiver3'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 25 doors, 3 pits
+	Total doors in connected path: 16
+	Trying trap exit: 2036 in room LeteCave1
+	Found 4 connections, selected: 3038 in room LeteRiver3
+Looking for reward in room LeteRiver3 ...
+Found a reward!  [('Lete River', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room LeteRiver3
+Making connection:  2036 --> 3038
+Processing reward:  Lete River
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Bahamut !
+	Updated Rewards Obtained:  0 Characters,  2 Espers
+	Updated Rewards Available:  6 Characters,  7 Espers
+	Updated branch checks available:
+	 0 :  ['Zozo', 'Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3']
+	 2 :  ['Whelk']
+Branch viability: [True, False, True] Stuck: {1}
+	trimmed dead end  ruin_hub_2
+Working on branch 2 ( ['Whelk'] )
+status: terminus ruin_terminus_1
+status: check rooms [65, 'ruin-whelk']
+status: dead ends ['ruin_terminus_1', 41, 47, 468, 'ms-wor-52']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 1 traps
+	Available entrances: 31 doors, 2 pits
+	Total doors in connected path: 5
+	Trying trap exit: 2075 in room 475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2
+	Found 2 connections, selected: 3075 in room ruin-thamasa
+Looking for reward in room ruin-thamasa ...
+Making connection:  2075 --> 3075
+	Active room:  ruin-thamasa .
+	Upstream nodes:  ['475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 29 doors, 1 pits
+	Total doors in connected path: 7
+	Trying door exit: 1261 in room ruin-thamasa
+	Found 28 connections, selected: 141 in room 36
+Looking for reward in room 36 ...
+Making connection:  1261 --> 141
+	Active room:  36_ruin-thamasa .
+	Upstream nodes:  ['475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 27 doors, 1 pits
+	Total doors in connected path: 7
+	Trying door exit: 1260 in room 36_ruin-thamasa
+	Found 26 connections, selected: 147 in room 38
+Looking for reward in room 38 ...
+Making connection:  1260 --> 147
+	Active room:  38_36_ruin-thamasa .
+	Upstream nodes:  ['475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 25 doors, 1 pits
+	Total doors in connected path: 7
+	Trying door exit: 1147 in room 38_36_ruin-thamasa
+	Found 24 connections, selected: 150 in room 43
+Looking for reward in room 43 ...
+Making connection:  1147 --> 150
+	Active room:  43_38_36_ruin-thamasa .
+	Upstream nodes:  ['475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 23 doors, 1 pits
+	Total doors in connected path: 7
+	Trying door exit: 142 in room 43_38_36_ruin-thamasa
+	Found 22 connections, selected: 987 in room 475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2
+Looking for reward in room 475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2 ...
+Making connection:  142 --> 987
+	Active room:  475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 23 doors, 1 pits
+	Total doors in connected path: 5
+	Trying door exit: 979 in room 475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 17 connections, selected: 155 in room 45
+Looking for reward in room 45 ...
+Making connection:  979 --> 155
+	Active room:  45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 21 doors, 1 pits
+	Total doors in connected path: 5
+	Trying door exit: 992 in room 45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 15 connections, selected: 146 in room 37a
+Looking for reward in room 37a ...
+Making connection:  992 --> 146
+	Active room:  37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 19 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 978 in room 37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 13 connections, selected: 153 in room 44
+Looking for reward in room 44 ...
+Making connection:  978 --> 153
+	Active room:  44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 17 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 152 in room 44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 11 connections, selected: 192 in room 65
+Looking for reward in room 65 ...
+Found a reward!  [('Narshe Moogle Defense', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 65
+		reward is locked by MOG . Saving for later.
+Making connection:  152 --> 192
+	Active room:  65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 15 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 151 in room 65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 9 connections, selected: 179 in room ruin-whelk
+Looking for reward in room ruin-whelk ...
+Found a reward!  [('Whelk', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room ruin-whelk
+Making connection:  151 --> 179
+Processing reward:  Whelk
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got STRAGO !
+	Set character path: STRAGO depends on TERRA
+		assessing key  STRAGO in rooms
+		assessing key  STRAGO in rooms
+		assessing key  STRAGO in rooms
+			Applying key: ('STRAGO',) in room ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+			adding a trap... 2054
+Forced same branch: EbotsRock VeldtCave 2
+		# rooms on each branch:  [45, 17, 29]
+Distributed areas:
+	 0 :  set()
+	 1 :  {'FanaticsTower'}
+	 2 :  {'EbotsRock'}
+Checks available:
+	 0 :  ['Zozo', 'Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower"]
+	 2 :  ['Whelk', "Ebot's Rock"]
+	Updated Rewards Obtained:  1 Characters,  2 Espers
+	Updated Rewards Available:  7 Characters,  8 Espers
+	Updated branch checks available:
+	 0 :  ['Zozo', 'Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower"]
+	 2 :  ["Ebot's Rock"]
+Branch viability: [True, False, True] Stuck: {1}
+Working on branch 2 ( ["Ebot's Rock"] )
+status: terminus ruin_terminus_1
+status: check rooms ['ms-wor-78']
+status: dead ends ['ruin_terminus_1', 41, 47, 468, 'ms-wor-52', 'ms-wor-78']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 1 traps
+	Available entrances: 13 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 154 in room ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 6 connections, selected: 166 in room 50
+Looking for reward in room 50 ...
+Making connection:  154 --> 166
+	Active room:  50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 1 traps
+	Available entrances: 11 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 1155 in room 50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 4 connections, selected: 167 in room 51
+Looking for reward in room 51 ...
+Making connection:  1155 --> 167
+	Active room:  51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 1 traps
+	Available entrances: 9 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 1143 in room 51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 2 connections, selected: 982 in room 470
+Looking for reward in room 470 ...
+Making connection:  1143 --> 982
+	Active room:  470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 1 traps
+	Available entrances: 7 doors, 0 pits
+	Total doors in connected path: 6
+	Trying door exit: 983 in room 470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+	Found 7 connections, selected: 1150 in room 41
+Looking for reward in room 41 ...
+Making connection:  983 --> 1150
+	Active room:  41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 1 traps
+	Available entrances: 6 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 178 in room 41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+	Found 6 connections, selected: 988 in room 472
+Looking for reward in room 472 ...
+Making connection:  178 --> 988
+		assessing key  vc1 in rooms
+			Applying key: ('vc1',) in room 472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+			adding a door... 989
+			removing key  vc1 from 472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Active room:  472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 1 traps
+	Available entrances: 5 doors, 0 pits
+	Total doors in connected path: 5
+	Trying door exit: 989 in room 472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+	Found 5 connections, selected: 1192 in room ms-wor-52
+Looking for reward in room ms-wor-52 ...
+Making connection:  989 --> 1192
+	Active room:  ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 1 traps
+	Available entrances: 4 doors, 0 pits
+	Total doors in connected path: 4
+	Trying door exit: 191 in room ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+	Found 4 connections, selected: 1546 in room ms-wor-78
+Looking for reward in room ms-wor-78 ...
+Found a reward!  [("Ebot's Rock", <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room ms-wor-78
+Making connection:  191 --> 1546
+Processing reward:  Ebot's Rock
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got CYAN !
+	Set character path: CYAN depends on STRAGO
+		assessing key  CYAN in rooms
+			Applying key: ('CYAN',) in room ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+			Applying a new key: zr1
+		assessing key  zr1 in rooms
+			Applying key: ('zr1',) in room 296r
+			adding a door... 618
+		assessing key  CYAN in rooms
+		assessing key  CYAN in rooms
+		# rooms on each branch:  [45, 18, 29]
+Forced same branch: MtZozo ZozoTower 0
+		# rooms on each branch:  [53, 51, 29]
+Distributed areas:
+	 0 :  {'MtZozo'}
+	 1 :  {'Doma'}
+	 2 :  {'Maranda'}
+Checks available:
+	 0 :  ['Zozo', 'Ancient Castle', 'Gau Father House', 'Mt. Zozo']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  ["Ebot's Rock"]
+	Updated Rewards Obtained:  2 Characters,  2 Espers
+	Updated Rewards Available:  8 Characters,  11 Espers
+	Updated branch checks available:
+	 0 :  ['Zozo', 'Ancient Castle', 'Gau Father House', 'Mt. Zozo']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  []
+Branch viability: [True, True, True] Stuck: {1}
+	trimmed dead end  ruin_hub_0
+Working on branch 0 ( ['Zozo', 'Ancient Castle', 'Gau Father House', 'Mt. Zozo'] )
+status: terminus ruin_terminus_2
+status: check rooms [532, 313, 'ms-wob-14', 256]
+status: dead ends ['ruin_terminus_2', '295r', 525, 526, 527, 532, '305r', 310, 312, 313, '294r', '309r', 'ms-wob-14', 'branch-mz_mapsafe', '306r', 256, 'root-mz_mapsafe', 251]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 40 doors, 3 pits
+	Total doors in connected path: 16
+	Trying door exit: 1082 in room ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 18 connections, selected: 4607 in room 296r
+Looking for reward in room 296r ...
+Making connection:  1082 --> 4607
+	Active room:  296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 37 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 1091 in room 296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 15 connections, selected: 541 in room 254
+Looking for reward in room 254 ...
+Making connection:  1091 --> 541
+	Active room:  254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 35 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 1100 in room 254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 13 connections, selected: 536 in room 252
+Looking for reward in room 252 ...
+Making connection:  1100 --> 536
+	Active room:  252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 33 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 1089 in room 252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 11 connections, selected: 542 in room 255
+Looking for reward in room 255 ...
+Making connection:  1089 --> 542
+	Active room:  255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 31 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 1279 in room 255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 9 connections, selected: 533 in room 250
+Looking for reward in room 250 ...
+Making connection:  1279 --> 533
+	Active room:  250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 29 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 543 in room 250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 7 connections, selected: 537 in room 253
+Looking for reward in room 253 ...
+Making connection:  543 --> 537
+	Active room:  253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 18 doors, 0 traps
+	Available entrances: 26 doors, 3 pits
+	Total doors in connected path: 18
+	Trying door exit: 4606 in room 253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 4 connections, selected: 1105 in room 531
+Looking for reward in room 531 ...
+Making connection:  4606 --> 1105
+	Active room:  531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 18 doors, 0 traps
+	Available entrances: 24 doors, 3 pits
+	Total doors in connected path: 18
+	Trying door exit: 618 in room 531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Found 2 connections, selected: 1276 in room 529
+Looking for reward in room 529 ...
+Making connection:  618 --> 1276
+	Active room:  529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 18 doors, 0 traps
+	Available entrances: 22 doors, 3 pits
+	Total doors in connected path: 18
+	Trying door exit: 636 in room 529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 22 connections, selected: 1225 in room 313
+Looking for reward in room 313 ...
+Found a reward!  [('Zozo', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 313
+Making connection:  636 --> 1225
+Processing reward:  Zozo
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Terrato !
+	Updated Rewards Obtained:  2 Characters,  3 Espers
+	Updated Rewards Available:  7 Characters,  10 Espers
+	Updated branch checks available:
+	 0 :  ['Ancient Castle', 'Gau Father House', 'Mt. Zozo']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  []
+Branch viability: [True, True, True] Stuck: {1}
+	trimmed dead end  313
+Working on branch 0 ( ['Ancient Castle', 'Gau Father House', 'Mt. Zozo'] )
+status: terminus ruin_terminus_2
+status: check rooms [532, 'ms-wob-14', 256]
+status: dead ends ['ruin_terminus_2', '295r', 525, 526, 527, 532, '305r', 310, 312, '294r', '309r', 'ms-wob-14', 'branch-mz_mapsafe', '306r', 256, 'root-mz_mapsafe', 251]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 17 doors, 0 traps
+	Available entrances: 21 doors, 3 pits
+	Total doors in connected path: 17
+	Trying door exit: 540 in room 313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 21 connections, selected: 637 in room 312
+Looking for reward in room 312 ...
+Making connection:  540 --> 637
+	Active room:  312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 16 doors, 0 traps
+	Available entrances: 20 doors, 3 pits
+	Total doors in connected path: 16
+	Trying door exit: 1277 in room 312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 20 connections, selected: 4631 in room 307r
+Looking for reward in room 307r ...
+Making connection:  1277 --> 4631
+	Active room:  307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 15 doors, 0 traps
+	Available entrances: 18 doors, 3 pits
+	Total doors in connected path: 16
+	Trying door exit: 1099 in room 307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 18 connections, selected: 4633 in room 309r
+Looking for reward in room 309r ...
+Making connection:  1099 --> 4633
+	Active room:  309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 14 doors, 0 traps
+	Available entrances: 17 doors, 3 pits
+	Total doors in connected path: 15
+	Trying door exit: 531 in room 309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 17 connections, selected: 1204 in room 256
+Looking for reward in room 256 ...
+Found a reward!  [('Mt. Zozo', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 256
+Making connection:  531 --> 1204
+Processing reward:  Mt. Zozo
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Shiva !
+	Updated Rewards Obtained:  2 Characters,  4 Espers
+	Updated Rewards Available:  6 Characters,  9 Espers
+	Updated branch checks available:
+	 0 :  ['Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  []
+Branch viability: [True, True, True] Stuck: {1}
+	trimmed dead end  312
+	trimmed dead end  309r
+	trimmed dead end  256
+Working on branch 0 ( ['Ancient Castle', 'Gau Father House'] )
+status: terminus ruin_terminus_2
+status: check rooms [532, 'ms-wob-14']
+status: dead ends ['ruin_terminus_2', '295r', 525, 526, 527, 532, '305r', 310, '294r', 'ms-wob-14', 'branch-mz_mapsafe', '306r', 'root-mz_mapsafe', 251]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 13 doors, 0 traps
+	Available entrances: 16 doors, 3 pits
+	Total doors in connected path: 14
+	Trying door exit: 5224 in room 256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 16 connections, selected: 1094 in room 525
+Looking for reward in room 525 ...
+Making connection:  5224 --> 1094
+	Active room:  525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 12 doors, 0 traps
+	Available entrances: 15 doors, 3 pits
+	Total doors in connected path: 13
+	Trying door exit: 538 in room 525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 15 connections, selected: 1107 in room 532
+Looking for reward in room 532 ...
+Found a reward!  [('Ancient Castle', <RewardType.ITEM|ESPER|CHARACTER: 14>)] in room 532
+Making connection:  538 --> 1107
+Processing reward:  Ancient Castle
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got MOG !
+	Set character path: MOG depends on EDGAR
+		assessing key  MOG in rooms
+		assessing key  MOG in rooms
+		assessing key  MOG in rooms
+	Unlocked reward Narshe Moogle Defense added to branch 2 checks
+Distributed areas:
+	 0 :  set()
+	 1 :  set()
+	 2 :  set()
+Checks available:
+	 0 :  ['Ancient Castle', 'Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  ['Narshe Moogle Defense']
+	Updated Rewards Obtained:  3 Characters,  4 Espers
+	Updated Rewards Available:  6 Characters,  9 Espers
+	Updated branch checks available:
+	 0 :  ['Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  ['Narshe Moogle Defense']
+	Unlocked an available reward! Narshe Moogle Defense on branch 2
+Processing reward:  Narshe Moogle Defense
+	choosing from... RewardType.ITEM|ESPER|CHARACTER
+	got Stray !
+	Updated Rewards Obtained:  3 Characters,  5 Espers
+	Updated Rewards Available:  4 Characters,  7 Espers
+	Updated branch checks available:
+	 0 :  ['Gau Father House']
+	 1 :  ['Floating Continent_1', 'Floating Continent_2', 'Floating Continent_3', "Fanatic's Tower", 'Doma WOR_2', 'Doma WOR_1', 'Doma WOR_3']
+	 2 :  ['Narshe Moogle Defense']
+Branch viability: [True, True, True] Stuck: {1}
+	trimmed dead end  41
+	trimmed dead end  ms-wor-52
+	trimmed dead end  ms-wor-78
+Working on branch 2 ( ['Narshe Moogle Defense'] )
+status: terminus ruin_terminus_1
+status: check rooms []
+status: dead ends ['ruin_terminus_1', 47, 468]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 1 traps
+	Available entrances: 5 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 165 in room ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+	Found 2 connections, selected: 5238 in room ms-wor-63
+Looking for reward in room ms-wor-63 ...
+Making connection:  165 --> 5238
+	Active room:  ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 1 traps
+	Available entrances: 3 doors, 0 pits
+	Total doors in connected path: 3
+	Trying door exit: 168 in room ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+	Found 3 connections, selected: 1079 in room ruin_terminus_1
+Looking for reward in room ruin_terminus_1 ...
+Making connection:  168 --> 1079
+	Active room:  ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 1 traps
+	Available entrances: 2 doors, 0 pits
+	Total doors in connected path: 2
+	Trying door exit: 5239 in room ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+		Filtered out path doors (path has only 2 doors)
+	Found 2 connections, selected: 158 in room 47
+Looking for reward in room 47 ...
+Making connection:  5239 --> 158
+	Active room:  47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 1 traps
+	Available entrances: 1 doors, 0 pits
+	Total doors in connected path: 1
+	Trying door exit: 145 in room 47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		Expanding search to all unconnected rooms...
+		Filtered out path doors (path has only 1 doors)
+		Warning: no rooms with 2+ doors, using any available
+	Found 1 connections, selected: 980 in room 468
+Looking for reward in room 468 ...
+Making connection:  145 --> 980
+	Active room:  468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 0 doors, 0 pits
+	Total doors in connected path: 0
+		Filtering exit 2054 - would strand pits in 468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 failed to extend, retry 1/3
+	Active room:  468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 0 doors, 0 pits
+	Total doors in connected path: 0
+		Filtering exit 2054 - would strand pits in 468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 failed to extend, retry 2/3
+	Active room:  468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa .
+	Upstream nodes:  [] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 1 traps
+	Available entrances: 0 doors, 0 pits
+	Total doors in connected path: 0
+		Filtering exit 2054 - would strand pits in 468_47_ruin_terminus_1_ms-wor-63_ms-wor-78_ms-wor-52_472_41_470_51_50_ruin-whelk_65_44_37a_45_475_471_40_467_ruin-narshe_474_42_49_469_ruin_hub_2_43_38_36_ruin-thamasa
+		No safe trap exits available
+	All connection strategies exhausted. Branch extension failed.
+Branch 2 is stuck after 3 retries
+Skipping reward processing for stuck branch 2
+Branch viability: [True, True, False] Stuck: {1, 2}
+	trimmed dead end  525
+	trimmed dead end  532
+Working on branch 0 ( ['Gau Father House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14']
+status: dead ends ['ruin_terminus_2', '295r', 526, 527, '305r', 310, '294r', 'ms-wob-14', 'branch-mz_mapsafe', '306r', 'root-mz_mapsafe', 251]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 11 doors, 0 traps
+	Available entrances: 14 doors, 3 pits
+	Total doors in connected path: 12
+	Trying door exit: 1106 in room 532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 14 connections, selected: 634 in room 310
+Looking for reward in room 310 ...
+Making connection:  1106 --> 634
+	Active room:  310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 10 doors, 0 traps
+	Available entrances: 13 doors, 3 pits
+	Total doors in connected path: 11
+	Trying door exit: 4622 in room 310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 13 connections, selected: 4603 in room 294r
+Looking for reward in room 294r ...
+Making connection:  4622 --> 4603
+	Active room:  294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 9 doors, 0 traps
+	Available entrances: 12 doors, 3 pits
+	Total doors in connected path: 10
+	Trying door exit: 1104 in room 294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+		Expanding search to all unconnected rooms...
+	Found 12 connections, selected: 625 in room 303a
+Looking for reward in room 303a ...
+Making connection:  1104 --> 625
+		assessing key  clock3 in rooms
+			removing key  clock3 from 303b
+			removing key  clock3 from 303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+	Active room:  303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  ['303b']
+	Available exits: 1 doors, 0 traps
+	Available entrances: 10 doors, 3 pits
+	Total doors in connected path: 10
+	Trying door exit: 626 in room 303b
+	Found 9 connections, selected: 4604 in room 303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1
+Looking for reward in room 303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1 ...
+Making connection:  626 --> 4604
+	Active room:  303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 7 doors, 0 traps
+	Available entrances: 10 doors, 3 pits
+	Total doors in connected path: 8
+	Trying door exit: 535 in room 303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 10 connections, selected: 30537 in room branch-mz_mapsafe
+Looking for reward in room branch-mz_mapsafe ...
+Making connection:  535 --> 30537
+	Active room:  branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 6 doors, 0 traps
+	Available entrances: 9 doors, 3 pits
+	Total doors in connected path: 7
+	Trying door exit: 1092 in room branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 9 connections, selected: 1095 in room 526
+Looking for reward in room 526 ...
+Making connection:  1092 --> 1095
+	Active room:  526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 5 doors, 0 traps
+	Available entrances: 8 doors, 3 pits
+	Total doors in connected path: 6
+	Trying door exit: 4621 in room 526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 8 connections, selected: 1057 in room ruin_terminus_2
+Looking for reward in room ruin_terminus_2 ...
+Making connection:  4621 --> 1057
+	Active room:  ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 4 doors, 0 traps
+	Available entrances: 7 doors, 3 pits
+	Total doors in connected path: 5
+	Trying door exit: 615 in room ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 7 connections, selected: 534 in room 251
+Looking for reward in room 251 ...
+Making connection:  615 --> 534
+	Active room:  251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 3 doors, 0 traps
+	Available entrances: 6 doors, 3 pits
+	Total doors in connected path: 4
+	Trying door exit: 1083 in room 251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 6 connections, selected: 30618 in room root-mz_mapsafe
+Looking for reward in room root-mz_mapsafe ...
+Making connection:  1083 --> 30618
+	Active room:  root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 2 doors, 0 traps
+	Available entrances: 5 doors, 3 pits
+	Total doors in connected path: 3
+	Trying door exit: 539 in room root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+	Found 5 connections, selected: 4629 in room 305r
+Looking for reward in room 305r ...
+Making connection:  539 --> 4629
+	Active room:  305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 1 doors, 0 traps
+	Available entrances: 4 doors, 3 pits
+	Total doors in connected path: 2
+	Trying door exit: 612 in room 305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+		Expanding search to all unconnected rooms...
+		Filtered out path doors (path has only 2 doors)
+	Found 4 connections, selected: 4630 in room 306r
+Looking for reward in room 306r ...
+Making connection:  612 --> 4630
+		assessing key  clock2 in rooms
+			removing key  clock2 from 306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 3 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 3 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 3 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [False, True, False] Stuck: {0, 1, 2}
+Adding reserve area MtKolts (16 rooms) to unstick branch 0
+	Added new check: Mt. Kolts
+	trimmed dead end  ruin_terminus_2
+	trimmed dead end  526
+	trimmed dead end  305r
+	trimmed dead end  310
+	trimmed dead end  294r
+	trimmed dead end  branch-mz_mapsafe
+	trimmed dead end  306r
+	trimmed dead end  root-mz_mapsafe
+	trimmed dead end  251
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 35 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 35 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 35 doors, 3 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area PhantomTrain (22 rooms) to unstick branch 0
+	Added new check: Phantom Train
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221]
+Forcing connections...
+Forcing:  2067 3067
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 81 doors, 6 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 81 doors, 6 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 81 doors, 6 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area EsperMountain (13 rooms) to unstick branch 0
+	Added new check: Esper Mountain
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494]
+Forcing connections...
+Forcing:  2011 3011
+forcing successful.
+Forcing:  2012 3012
+forcing successful.
+Forcing:  2013 3013
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 103 doors, 9 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 103 doors, 9 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 103 doors, 9 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Vector (12 rooms) to unstick branch 0
+	Added new check: Magitek Factory_1
+	Added new check: Magitek Factory_2
+	Added new check: Magitek Factory_3
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352]
+Forcing connections...
+Forcing:  2023 3023
+forcing successful.
+Forcing:  2128 3128
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 118 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 118 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 118 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area DarylsTomb (16 rooms) to unstick branch 0
+	Added new check: Daryl's Tomb
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392]
+Forcing connections...
+Forcing:  2059 3059
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 145 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 145 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 145 doors, 15 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area UmarosCave (9 rooms) to unstick branch 0
+	Added new check: Umaro's Cave
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave"] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392]
+Forcing connections...
+Forcing:  2005 3005
+forcing successful.
+Forcing:  2006 3006
+forcing successful.
+Forcing:  2007 3007
+forcing successful.
+Forcing:  2008 3008
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 155 doors, 22 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 155 doors, 22 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 155 doors, 22 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area ZoneEater (9 rooms) to unstick branch 0
+	Added new check: Zone Eater
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363]
+Forcing connections...
+Forcing:  2043 3043
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 169 doors, 24 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 169 doors, 24 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 169 doors, 24 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Jidoor (9 rooms) to unstick branch 0
+	Added new check: Auction House_1
+	Added new check: Auction House_2
+	Added new check: Owzer Mansion
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 182 doors, 28 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 182 doors, 28 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 182 doors, 28 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area CrescentMtn (11 rooms) to unstick branch 0
+	Added new check: Serpent Trench
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284]
+Forcing connections...
+Forcing:  2046 3046
+forcing successful.
+Forcing:  2049 3049
+forcing successful.
+Forcing:  2053 3053
+forcing successful.
+Forcing:  2153 3153
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 187 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 187 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 187 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area SouthFigaroCave (6 rooms) to unstick branch 0
+	Added new check: South Figaro Cave
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104]
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 199 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 199 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 199 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area BarenFalls (3 rooms) to unstick branch 0
+	Added new check: Baren Falls
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+Forcing:  2076 3076
+forcing successful.
+Forcing:  2176 3176
+forcing successful.
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Nikeah (1 rooms) to unstick branch 0
+	Skipping room ruin-nikeah - already exists
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 201 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area ImperialCamp (1 rooms) to unstick branch 0
+	Added new check: Imperial Camp
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 203 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 203 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 203 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Kohlingen (1 rooms) to unstick branch 0
+	Added new check: Kohlingen
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 205 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 205 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 205 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area ImperialCastle (1 rooms) to unstick branch 0
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103]
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 213 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 213 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 213 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Veldt (1 rooms) to unstick branch 0
+	Added new check: Veldt
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 214 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 214 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 214 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Tzen (1 rooms) to unstick branch 0
+	Added new check: Tzen
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt', 'Tzen'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt', 'ms-wor-51']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt', 'ms-wor-51']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 215 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 215 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 215 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area OperaHouse (1 rooms) to unstick branch 0
+	Added new check: Opera House
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt', 'Tzen', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt', 'ms-wor-51', 'ms-wob-40']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt', 'ms-wor-51', 'ms-wob-40']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 216 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 216 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 216 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area Cid (1 rooms) to unstick branch 0
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt', 'Tzen', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt', 'ms-wor-51', 'ms-wob-40']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt', 'ms-wor-51', 'ms-wob-40', 'ms-wor-48']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 217 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 217 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 217 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding reserve area PhoenixCave (1 rooms) to unstick branch 0
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt', 'Tzen', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt', 'ms-wor-51', 'ms-wob-40']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt', 'ms-wor-51', 'ms-wob-40', 'ms-wor-48', 'ms-wor-1554']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+Adding extra area ImperialCastle to unstick branch 0
+	Skipping room 331 - already exists
+Working on branch 0 ( ['Gau Father House', 'Mt. Kolts', 'Phantom Train', 'Esper Mountain', 'Magitek Factory_1', 'Magitek Factory_2', 'Magitek Factory_3', "Daryl's Tomb", "Umaro's Cave", 'Zone Eater', 'Auction House_1', 'Auction House_2', 'Owzer Mansion', 'Serpent Trench', 'South Figaro Cave', 'Baren Falls', 'Imperial Camp', 'Kohlingen', 'Veldt', 'Tzen', 'Opera House'] )
+status: terminus ruin_terminus_2
+status: check rooms ['ms-wob-14', 151, 220, 488, 349, 354, 'ruin-mtek3', 'ruin-daryl', 368, 363, 'dc-73', 284, 'ruin-st-exit', 104, 'ruin-baren-reward', 'dc-1501', 'ms-wor-59', 'wor-veldt', 'ms-wor-51', 'ms-wob-40']
+status: dead ends ['295r', 527, 'ms-wob-14', 147, 149, 157, '203c', '206a', '206b', '207a', '207b', 212, 213, '215a', '215b', 221, 490, 493, 494, 352, 380, 384, 386, 389, 392, 363, 279, 284, 103, 'wor-veldt', 'ms-wor-51', 'ms-wob-40', 'ms-wor-48', 'ms-wor-1554']
+Forcing connections...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 1/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 failed to extend, retry 2/3
+	Active room:  306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b .
+	Upstream nodes:  ['308r'] 
+	Downstream nodes:  []
+	Available exits: 0 doors, 0 traps
+	Available entrances: 218 doors, 35 pits
+	Total doors in connected path: 1
+	No exits available!
+Branch 0 is stuck after 3 retries
+Skipping reward processing for stuck branch 0
+Branch viability: [True, True, False] Stuck: {0, 1, 2}
+ERROR: No reserve areas available to unstick branches!
+Closing branch...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	hub: 306r_305r_root-mz_mapsafe_251_ruin_terminus_2_526_branch-mz_mapsafe_303a_294r_310_532_525_256_309r_307r_312_313_529_531_253_250_255_252_254_296r_ruin-returners_300_523_301r_311_524_522_304_298_521_ruin-zozo_ruin_hub_0_299_530_528_520_302_297_LeteRiver3_LeteCave1_303b [0, 0, 0, 0, 0]
+	pits: []
+	traps: []
+(2) delta values: []
+(4) remaining doors: []
+(4) terminus already merged into hub, skipping
+(6) remaining dead ends: [380, '207a', 386, 279, 'ms-wob-40', 527, 149, '206b', 384, 'ms-wor-48', 363, 284, 221, 494, 147, '206a', 103, 490, 'ms-wor-1554', 352, 157, '215b', 213, 392, '295r', 'ms-wor-51', 493, 'ms-wob-14', 389, 212, '203c', '207b', 'wor-veldt', '215a']
+... closing branch complete!
+Closing branch...
+added doors to protected:  {2176, 2049, 3076, 2053, 2055, 2059, 2060, 2061, 2062, 2063, 2064, 2039, 2067, 3097, 3098, 3099, 2076, 2097, 2098, 2099, 3128, 3005, 3006, 3007, 3008, 3011, 3012, 3013, 3067, 3023, 2128, 3153, 2005, 2006, 2007, 2008, 3029, 3030, 2011, 2012, 2013, 3032, 3033, 3039, 3043, 3046, 2023, 3176, 3049, 2153, 2029, 2030, 3053, 2032, 2033, 3055, 3059, 3060, 3061, 3062, 3063, 3064, 2043, 2046}
+	hub: 509_ruin_hub_1 [1, 0, 0, 0, 0]
+	pits: [3031]
+	traps: [2031]
+(2) delta values: [(0, 510), (0, 'ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508')]
+(2) selected ruin-figarocastle_ruin_terminus_3_507_503_505_502_506_ms-wor-58_512_508 (delta =  0 ):  [0, 1, 1, 0, 0] [] [2031] [3031]
+		looking for available pido nodes:
+			 425 :  [1, 1, 2, 0, 0]
+			 428 :  [1, 1, 2, 0, 0]
+			 433 :  [2, 0, 1, 0, 0]
+			 210 :  [1, 0, 1, 0, 0]
+			 188B :  [1, 0, 1, 0, 0]
+(2) connecting 2031 --> 433
+
+Traceback (most recent call last):
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\wc.py", line 58, in <module>
+    main()
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\wc.py", line 12, in main
+    events = Events(memory.rom, args, data)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 25, in __init__
+    events = self.mod()
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 74, in mod
+    self.ruination_mod(events, name_event)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\events.py", line 249, in ruination_mod
+    self.maps.doors.map = ruin_map.generate_map_with_characters(self.characters, self.espers, self.items)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\ruination.py", line 1636, in generate_map_with_characters
+    branch.finalize_map()
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\event\ruination.py", line 516, in finalize_map
+    self.connect(this_exit, this_conn)
+  File "C:\Users\hansr\Documents\GitHub\WorldsCollide\data\walks.py", line 80, in connect
+    self.net.add_edge(R1.id, R2.id)
+AttributeError: 'NoneType' object has no attribute 'id'

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -489,7 +489,10 @@ class RuinationBranch(Network):
                                 print('\t\t\t', node_id, ': ', node.count)
 
                     if len(pido) > 0:
-                        this_conn = random.choice(pido)
+                        pido_room_id = random.choice(pido)
+                        pido_room = self.rooms.get_room(pido_room_id)
+                        # Select a pit from the converter room as the connection target
+                        this_conn = random.choice(list(pido_room.pits))
 
                 elif len(room.doors) > 0 and len(upstream_doors) == 0 and len(upstream_pits) > 0:
                     # Need a door-in, trap-out converter
@@ -504,7 +507,10 @@ class RuinationBranch(Network):
                                 print('\t\t\t', node_id, ': ', node.count)
 
                     if len(dito) > 0:
-                        this_conn = random.choice(dito)
+                        dito_room_id = random.choice(dito)
+                        dito_room = self.rooms.get_room(dito_room_id)
+                        # Select a door from the converter room as the connection target
+                        this_conn = random.choice(list(dito_room.doors))
 
             if this_conn is None:
                 # There is no solution.


### PR DESCRIPTION
…connections

When selecting pido (pit-in, door-out) or dito (door-in, trap-out) converter rooms, the code was setting this_conn to the room ID instead of selecting an actual element (pit or door) from that room.

This caused connect() to fail with AttributeError when trying to find a room containing the "element" (which was actually a room ID).

Fixed by selecting the appropriate element type from the converter room after choosing it.