### PR TITLE
Fix ruination mode compile error: KeyError 1291

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -456,7 +456,8 @@ class Maps():
         self.chests.mod()
         self.world_map.mod()
         self.doors.mod()
-        if self.args.door_randomize or self.args.map_shuffle:
+        if (self.args.door_randomize or self.args.map_shuffle) and not self.args.ruination_mode:
+            # Skip for ruination mode - door map is constructed later in ruination_mod()
             self.postprocess_door_map()
         self.events.mod()  # self.events.mod(self.doors, self)
         self.long_events.mod()  # LONG EVENTS


### PR DESCRIPTION
Skip postprocess_door_map() call in maps.mod() for ruination mode.

The issue was that postprocess_door_map() was being called twice:
1. First in maps.mod() - but doors.map was empty at this point
2. Second in ruination_mod() - after actual connections were created

The first call ran the dungeon_crawl_exit_destination_override code which modified exit_data (e.g., exit_data[360][0] = 1291). When the second call ran, the WoR exits code (lines 529-534) used these modified values, causing safe_id values like 1291 to be added to door_map.

Later, connect_exits() tried to look up exit_data[1291] which doesn't exist, causing the KeyError.

For ruination mode, the door map is constructed in ruination_mod(), which calls postprocess_door_map() itself, so the call in maps.mod() should be skipped.