### PR TITLE
Fix actual cause of KeyError 1291: exit_make_explicit in connect_exits

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -830,7 +830,8 @@ class Maps():
         map = self.door_map
 
         # Need to add modified world map exits if they weren't randomized (to print exit events)
-        if self.args.door_randomize:
+        # Skip for ruination mode - exit_data has been modified by dungeon_crawl override
+        if self.args.door_randomize and not self.args.ruination_mode:
             # Only do this if door_randomize, not map_shuffle
             for m in exit_make_explicit.keys():
                 if m not in map.keys():


### PR DESCRIPTION
The previous fix was incomplete. The actual sequence was:

1. postprocess_door_map() modifies exit_data[360][0] = 1291 (dungeon_crawl override)
2. door_map doesn't include door 360 (not part of ruination connections)
3. In connect_exits(), lines 833-837 add entries from exit_make_explicit
4. Door 360 is in exit_make_explicit and not in map, so map[360] = exit_data[360][0] = 1291
5. When processing door 360 later, exit_data[1291] is looked up -> KeyError

Fix: Skip the exit_make_explicit code block for ruination mode since exit_data has been modified by the dungeon_crawl override at that point.