### PR TITLE
Fix ruination mode crash: add ruination_mode to VeldtCaveWOR.DOOR_RAN…

### DIFF
--- a/event/veldt_cave_wor.py
+++ b/event/veldt_cave_wor.py
@@ -9,7 +9,8 @@ class VeldtCaveWOR(Event):
                           or args.door_randomize_all
                           or args.door_randomize_crossworld
                           or args.door_randomize_dungeon_crawl
-                          or args.door_randomize_each)
+                          or args.door_randomize_each
+                          or args.ruination_mode)
         self.MAP_SHUFFLE = args.map_shuffle
 
     def name(self):


### PR DESCRIPTION
…DOMIZE

In ruination mode, the ruin-thamasa room contains pit 3075 (Veldt Cave destination). When the Transitions class processes a connection to this pit, it looks up trap 2075 in event_exit_info. However, entry 2075 has event_length=0 as a placeholder that gets updated dynamically in VeldtCaveWOR.move_to_thamasa().

The issue was that VeldtCaveWOR.DOOR_RANDOMIZE didn't include args.ruination_mode, so the update never happened in ruination mode, leaving the entry with length 0 and causing an IndexError when Transitions tried to read the (non-existent) event code.

The fix adds args.ruination_mode to the DOOR_RANDOMIZE condition, matching the pattern used in other events like imperial_camp.py.