### PR TITLE
Fix KeyError in verbose door connection output for logical link doors

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -626,7 +626,10 @@ class Maps():
             for m in self.doors.map[0]:
                 ma = [a for a in m]
                 ma.sort()
-                print('\t' + str(ma[0]) + "<-->" + str(ma[1]) + '\t(' + exit_data[ma[0]][1] + '<-->' + exit_data[ma[1]][1] + ')')
+                # Use door_descr if available, otherwise try exit_data, otherwise show ID
+                desc0 = self.doors.door_descr.get(ma[0], exit_data.get(ma[0], [None, f'ID:{ma[0]}'])[1])
+                desc1 = self.doors.door_descr.get(ma[1], exit_data.get(ma[1], [None, f'ID:{ma[1]}'])[1])
+                print('\t' + str(ma[0]) + "<-->" + str(ma[1]) + '\t(' + desc0 + '<-->' + desc1 + ')')
             print('One-way connections:')
             for m in self.doors.map[1]:
                 print('\t', m[0], " -> ", m[1])


### PR DESCRIPTION
When Doors.verbose is True, postprocess_door_map() prints door connection descriptions by looking up door IDs in exit_data. However, logical link door IDs (like 30537, 30618 used for Mt Zozo connections) don't exist in exit_data, causing a KeyError.

Fix by using safe lookup with fallback: first try door_descr dict, then exit_data with .get(), falling back to showing the raw ID. This prevents crashes and aids debugging when logical links aren't fully processed.