### PR TITLE
Fix ruination mode crash: add ruination_mode to FigaroCastleWOR.MAP_S…

### DIFF
--- a/event/figaro_castle_wor.py
+++ b/event/figaro_castle_wor.py
@@ -4,7 +4,7 @@ from event.switchyard import AddSwitchyardEvent, GoToSwitchyard
 class FigaroCastleWOR(Event):
     def __init__(self, events, rom, args, dialogs, characters, items, maps, enemies, espers, shops, warps):
         super().__init__(events, rom, args, dialogs, characters, items, maps, enemies, espers, shops, warps)
-        self.MAP_SHUFFLE = args.map_shuffle or args.door_randomize_dungeon_crawl
+        self.MAP_SHUFFLE = args.map_shuffle or args.door_randomize_dungeon_crawl or args.ruination_mode
 
     def name(self):
         return "Figaro Castle WOR"


### PR DESCRIPTION
…HUFFLE

Similar to the VeldtCaveWOR fix, FigaroCastleWOR.MAP_SHUFFLE didn't include args.ruination_mode. This meant map_shuffle_mod() was never called in ruination mode, and AddSwitchyardEvent(1507, ...) was never executed.

Later, maps.write() tries to update event_exit_info[1507] by looking up the switchyard tile coordinates via switchyard_xy(1507), but the tile doesn't exist because it was never created.

Error: IndexError: get_event: could not find event at 6 1