### PR TITLE
Add Narshe school door (144) to ruin-narshe room for destination rand…

### DIFF
--- a/data/rooms.py
+++ b/data/rooms.py
@@ -183,7 +183,7 @@ room_data = {
     'ruin-baren-reward': [ [ ], [2176], [3076], 0],  # End for Baren Falls with reward, logically forced to Veldt Shore
     'ruin-baren': [ [1194, 1195], [], [3176], 0],  # End for Baren Falls: door exit to (somewhere)
     'ruin-whelk': [ [178, 179], [ ], [ ], [], {"TERRA": [1155]}, 0],  #Narshe Northern Mines Main Hallway WoB.  Reskin map tileset?
-    'ruin-narshe': [[1143, 1146, 140, 143], [], [], 1],         # Narshe WOR, incl. secret passage & entrance to south caves
+    'ruin-narshe': [[1143, 1146, 140, 143, 144], [], [], 1],         # Narshe WOR, incl. secret passage & entrance to south caves & school
     'ruin-zozo': [ [4600, 4601, 4602, 4604, 5224], [ ], [ ], [], {"TERRA": [608], "CYAN": ['zr1']}, 1], #Zozo 1F Outside WOR + Terra-locked 608
 
 


### PR DESCRIPTION
…omization

In ruination mode, the Narshe school is used as a hub. The Narshe WoR map includes door 144 which by default connects to the school. Adding this door to the ruin-narshe room ensures its destination gets randomized like the other doors in the area.

https://claude.ai/code/session_0157q3TJnr4MKN1JBVRtaGkf