### PR TITLE
Rewrite sealed gate ruination_mod with Python field functions

### DIFF
--- a/event/sealed_gate.py
+++ b/event/sealed_gate.py
@@ -200,89 +200,200 @@ class SealedGate(Event):
         self.kefka_npc.event_bit = npc_bit.event_bit(npc_bit.ALWAYS_OFF)
         self.kefka_npc.event_byte = npc_bit.event_byte(npc_bit.ALWAYS_OFF)
 
-        # Sealed Gate event edits:
         # Move event tile up one square, to allow party to retreat
         event_in = self.maps.get_event(map_id, 8, 21)
         event_in.y -= 1
-        space = Reserve(0xb39e6, 0xb39e6, "sealed gate event moved up 1 tile", field_entity.Move(direction.UP, 4))
 
-        # Skip reform party & enable party to move thru things
-        space = Reserve(0xb39e8, 0xb39f8, "sealed gate skip split party", field.NOP())
-        # Skip party split animation
-        space = Reserve(0xb39fa, 0xb3a12, "sealed gate edits 2", field.NOP())
-        # Skip dialog "This is the sealed gate..."
-        space = Reserve(0xb3a23, 0xb3a25, "sealed gate edits 3", field.NOP())
-        # Skip party-dependent dialog options
-        space = Reserve(0xb3a32, 0xb3a35, "sealed gate edits 3a", field.NOP())
-        # Change terra movement to party movement
-        space = Reserve(0xb3a3d, 0xb3a3d, "sealed gate change animation 1", field.NOP())
-        space.write(field_entity.PARTY0)
-        # Skip split party move & dialog "Terra..."
-        space = Reserve(0xb3a42, 0xb3a56, "sealed gate edits 4", field.NOP())
-        # Change terra movement to party movement
-        space = Reserve(0xb3a63, 0xb3a63, "sealed gate change animation 2", field.NOP())
-        space.write(field_entity.PARTY0)
-        # Skip split party animation
-        space = Reserve(0xb3a94, 0xb3a9f, "sealed gate edits 5", field.NOP())
-        # Change terra movement to party movement
-        space = Reserve(0xb3aa0, 0xb3aa0, "sealed gate change animation 3", field.NOP())
-        space.write(field_entity.PARTY0)
-        # Skip dialog "Terra!  ... the gate... quickly!"
-        space = Reserve(0xb3aa4, 0xb3aac, "sealed gate edits 5", field.NOP())
-        # Change terra movement to party movement
-        space = Reserve(0xb3ab1, 0xb3ab1, "sealed gate change animation 4", field.NOP())
-        space.write(field_entity.PARTY0)
-        # Skip replace a party member with Kefka
-        space = Reserve(0xb3aba, 0xb3adb, "sealed gate edits 6", field.NOP())
-        # Modify invoked battle
-        space = Reserve(0xb3adc, 0xb3ae2, "sealed gate battle mod", field.NOP())
-
+        # Get boss pack for the battle
         boss_pack_id = self.get_boss("Ultros/Chupon")
-        space.write(field.InvokeBattleType(boss_pack_id, field.BattleType.BACK))
 
-        # Skip unreplace a party member with Kefka
-        space = Reserve(0xb3ae3, 0xb3ae5, "sealed gate edits 7", field.NOP())
-        space.write(field.SetEventBit(event_bit.SEALED_GATE_OPENED))  # stop Sealed Gate event from repeating
+        # Write complete new sealed gate event using Python field functions
+        # This replaces the complex original event with surgical patches
+        src = [
+            # Check if event already completed - if so, return immediately
+            field.ReturnIfEventBitSet(event_bit.SEALED_GATE_OPENED),
 
-        # Skip replace character positions after battle
-        space = Reserve(0xb3aea, 0xb3afd, "sealed gate edits 8", field.NOP())
-        space.write([
+            # Play wind song and set party to layer 2 (above background)
+            field.StartSongAtVolume(0x39, 0x78),
+            field.Call(self.lightning_strike),
+            field.Call(SET_PARTY_LAYER2),
+
+            # Create the gate guardian NPCs (espers behind gate)
+            field.CreateEntity(0x16),
+            field.CreateEntity(0x17),
+            field.CreateEntity(0x18),
+            field.RefreshEntities(),
+
+            # Party walks up toward the gate
+            field.EntityAct(field_entity.PARTY0, True,
+                            field_entity.SetSpeed(field_entity.Speed.SLOW),
+                            field_entity.Move(direction.UP, 4)),
+
+            # Hold screen and pause before panning up
+            field.HoldScreen(),
+            field.Pause(1.0),
+
+            # Camera pans up to show the gate
+            field.EntityAct(field_entity.CAMERA, True,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.UP, 7)),
+
+            # Pause to let player see the gate
+            field.Pause(1.5),
+
+            # Increase song volume and lightning strike
+            field.FadeSongVolume(100, 0x96),
+            field.Call(0xb38ac),  # lightning strike variant (right side)
+
+            # Pause to build tension
+            field.Pause(2.0),
+
+            # Camera pans back down
+            field.EntityAct(field_entity.CAMERA, True,
+                            field_entity.SetSpeed(field_entity.Speed.SLOW),
+                            field_entity.Move(direction.DOWN, 4)),
+
+            # Lightning strike and pause
+            field.Call(self.lightning_strike),
+            field.Pause(1.5),
+
+            # Increase song volume more
+            field.FadeSongVolume(50, 0xc8),
+            field.Pause(1.5),
+
+            # Free screen briefly for party movement
+            field.FreeScreen(),
+
+            # Party approaches the gate
+            field.EntityAct(field_entity.PARTY0, True,
+                            field_entity.SetSpeed(field_entity.Speed.SLOW),
+                            field_entity.Move(direction.UP, 5)),
+
+            # Increase to full volume and lightning
+            field.Pause(0.5),
+            field.FadeSongVolume(100, 0xff),
+            field.Call(self.lightning_strike),
+            field.Pause(0.5),
+
+            # Show the esper NPCs
+            field.ShowEntity(0x16),
+            field.ShowEntity(0x17),
+            field.ShowEntity(0x18),
+
+            # Set NPCs to layer 2
+            field.EntityAct(0x16, True,
+                            field_entity.SetSpriteLayer(2)),
+            field.EntityAct(0x17, True,
+                            field_entity.SetSpriteLayer(2)),
+            field.EntityAct(0x18, True,
+                            field_entity.SetSpriteLayer(2)),
+
+            # Pause and hold screen
+            field.Pause(0.75),
+            field.HoldScreen(),
+            field.Pause(1.0),
+
+            # Mute song, play dramatic sound
+            field.FadeSongVolume(0, 0x00),
+            field.PlaySoundEffect(205),
+            field.Pause(2.0),
+
+            # Camera quickly moves down
+            field.PauseUnits(15),
+            field.EntityAct(field_entity.CAMERA, False,
+                            field_entity.SetSpeed(field_entity.Speed.FAST),
+                            field_entity.Move(direction.DOWN, 7)),
+
+            # Play battle music
+            field.StartSongAtVolume(0x1f, 0xff),  # Metamorphosis
+            field.WaitForEntityAct(field_entity.CAMERA),
+            field.Pause(0.5),
+
+            # Party turns down to face threat
+            field.EntityAct(field_entity.PARTY0, True,
+                            field_entity.Turn(direction.DOWN)),
+
+            field.Pause(0.75),
+
+            # Fade out and invoke battle
+            field.FadeOutScreen(),
+            field.WaitForFade(),
+
+            # Boss battle
+            field.InvokeBattleType(boss_pack_id, field.BattleType.BACK),
+
+            # After battle - set event bit to prevent repeat
+            field.SetEventBit(event_bit.SEALED_GATE_OPENED),
+
+            # Hide the esper NPCs
+            field.HideEntity(0x16),
             field.HideEntity(0x17),
             field.HideEntity(0x18),
-            field.HideEntity(0x16),
             field.RefreshEntities(),
-        ])
-        # Skip move characters after battle
-        space = Reserve(0xb3b03, 0xb3b11, "sealed gate edits 9", field.NOP())
-        space.write(field.FadeInScreen())
-        # Change terra movement to party movement
-        space = Reserve(0xb3b12, 0xb3b12, "sealed gate change animation 5", field.NOP())
-        space.write(field_entity.PARTY0)
-        # Skip "Espers... please heed my call...""
-        space = Reserve(0xb3b16, 0xb3b1d, "sealed gate edits 10", field.NOP())
-        # Skip character animations, rumbling, 2nd battle
-        space = Reserve(0xb3b45, 0xb3b76, "sealed gate edits 11", field.NOP())
 
-        #space = Reserve(0xb3b66, 0xb3b76, "sealed gate edits 12", field.NOP())
-        space.write([
-            #field.StopScreenShake(),
-            field.FadeSoundEffect(40, 0x00),   # Fade currently playing sound effect to 0x00 over time 40
-            field.StartSongAtVolume(0x39, 0x96),  # Play song 0x39 ('wind') at volume 0x96
+            # Play wind song and fade in
+            field.StartSongAtVolume(0x39, 0x96),
+            field.FadeInScreen(),
+
+            # Party turns up toward the gate
+            field.EntityAct(field_entity.PARTY0, True,
+                            field_entity.Turn(direction.UP)),
+
+            field.Pause(0.5),
+
+            # Play gate opening sound
+            field.FadeSoundEffect(0, 0x64),
+            field.PlaySoundEffect(165),
+            field.Pause(2.0),
+
+            # Gate opens - move the gate NPCs (door pieces) apart
+            field.EntityAct(0x10, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+            field.EntityAct(0x12, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+            field.EntityAct(0x13, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+            field.EntityAct(0x11, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+            field.EntityAct(0x14, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+            field.EntityAct(0x15, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+
+            # Wait for gate animation
+            field.Pause(1.5),
+
+            # Fade out sound effect
+            field.FadeSoundEffect(40, 0x00),
+
+            # Camera moves down a bit
             field.EntityAct(field_entity.CAMERA, True,
                             field_entity.SetSpeed(field_entity.Speed.SLOW),
                             field_entity.Move(direction.DOWN, 2)),
-            field.WaitForEntityAct(field_entity.CAMERA),
-            #field.Call(SET_PARTY_LAYER0),
-            field.FreeScreen(),
-            field.Return()
-        ])
 
-        # Polish timing (it's a bit slow in places).
-        # Option: Move event tile back down; show "this is the sealed gate" text; add dialog option to open it?
+            # Set party back to layer 0 and free screen
+            field.Call(SET_PARTY_LAYER0),
+            field.FreeScreen(),
+            field.Return(),
+        ]
+        space = Write(Bank.CB, src, "sealed gate ruination event")
+        new_event_addr = space.start_address
+
+        # Patch the original event start to branch to our new event
+        # Original event starts at 0xb39ca with a check for event bit 0x079
+        space = Reserve(0xb39ca, 0xb39d7, "sealed gate branch to new event", field.NOP())
+        space.write(
+            field.Branch(new_event_addr),
+        )
 
         # Add exit tile at sealed gate to KT
         from event.switchyard import GoToSwitchyard
-        # Available dialogs:  0x0666--0x066A (individual dialog options for characters at sealed gate)
         kt_enter_id = 2077
 
         dialog_entry_id = 0x0666
@@ -293,34 +404,26 @@ class SealedGate(Event):
             field.HoldScreen(),
             field.EntityAct(field_entity.CAMERA, True,
                             field_entity.SetSpeed(field_entity.Speed.SLOW),
-                            field_entity.Move(direction.UP, 2)
-                            ),
+                            field_entity.Move(direction.UP, 2)),
             field.BranchIfEventBitSet(event_bit.ENABLE_Y_PARTY_SWITCHING, "ALLOW_ENTRY"),
             field.Dialog(no_return_text),
             "DO_NOT_ENTER",
             field.EntityAct(field_entity.CAMERA, True,
-                            field_entity.Move(direction.DOWN, 2)
-                            ),
+                            field_entity.Move(direction.DOWN, 2)),
             field.FreeScreen(),
             field.EntityAct(field_entity.PARTY0, True,
                             field_entity.SetSpeed(field_entity.Speed.SLOW),
-                            field_entity.Move(direction.DOWN, 2),
-                            ),
+                            field_entity.Move(direction.DOWN, 2)),
             field.Return(),
             "ALLOW_ENTRY",
             field.DialogBranch(dialog_entry_id, dest1="ENTER_KT", dest2="DO_NOT_ENTER"),
             "ENTER_KT",
             field.EntityAct(field_entity.PARTY0, False,
                             field_entity.SetSpeed(field_entity.Speed.SLOW),
-                            field_entity.Move(direction.UP, 3),
-                            #field_entity.SetSpriteLayer(0),
-                            #field_entity.Move(direction.UP, 1),
-                            ),
-            #field.Pause(1),
+                            field_entity.Move(direction.UP, 3)),
             field.EntityAct(field_entity.CAMERA, True,
-                            field_entity.Move(direction.UP, 2),
-                            ),
-            field.Call(0xb38ac),  # self.lightning_strike
+                            field_entity.Move(direction.UP, 2)),
+            field.Call(0xb38ac),  # lightning strike
             field.HideEntity(field_entity.PARTY0),
             field.Pause(1),
             field.FadeOutScreen(),
@@ -345,7 +448,7 @@ class SealedGate(Event):
             Read(patch_addr[0], patch_addr[1]),
             field.ReturnIfEventBitClear(event_bit.SEALED_GATE_OPENED),
             field.EntityAct(0x10, False,
-                            field_entity.SetPosition(6,5)),
+                            field_entity.SetPosition(6, 5)),
             field.EntityAct(0x12, False,
                             field_entity.SetPosition(6, 7)),
             field.EntityAct(0x13, False,


### PR DESCRIPTION
The original ruination_mod used surgical patches on the vanilla event code, which was error-prone and difficult to debug. This rewrite creates a complete new event using Python field functions that's easier to understand and maintain.

The new event flow:
1. Check if already completed (return if so)
2. Play wind song, lightning effects
3. Party walks toward gate
4. Camera pans up to show the gate
5. Boss battle (Ultros/Chupon)
6. Gate opens (NPCs move apart)
7. Return control to player

Also preserved:
- KT access event at position (8, 9)
- Entrance event modification to show opened gate
- Map song set to wind

https://claude.ai/code/session_01MbrMxTdeebWgwwCKTGRAYe