### PR TITLE
Add exit 1561 to exit_data for Veldt Shore entrance

### DIFF
--- a/data/map_exit_extra.py
+++ b/data/map_exit_extra.py
@@ -1375,6 +1375,7 @@ exit_data = {
     1558: [1082, "Figaro Castle prison to Ancient Cave"],
     1559: [1560, "Imperial base west entrance for dungeon crawl"],
     1560: [1559, "Imperial base west exit to world map for dungeon crawl"],
+    1561: [1194, "Veldt WoB to Veldt Shore entrance"],
     1563: [1564, "Darill's tomb door behind sarcophagus to staircase"],
     1564: [1563, "Darill's tomb staircase top to tomb"],
 


### PR DESCRIPTION
Exit 1561 (Veldt WoB to Veldt Shore) was defined in event_exit_info and event_door_connection_data, but was missing from exit_data. This caused a KeyError in postprocess_door_map() because exit_maps is only populated from exit_data keys.

Add the missing entry with partner 1194 (Veldt Shore South exit).