### PR TITLE
Fix crash when all planned characters obtained but character slot rem…

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -1712,7 +1712,8 @@ class ruination_map():
             if self.verbose:
                 print('Processing reward: ', reward_name)
 
-            if self.RewardsAvailable[0] == 1 and (slot.possible_types & RewardType.CHARACTER):
+            remaining_chars_needed = len(self.planned_characters) - self.RewardsObtained[0]
+            if remaining_chars_needed >= 1 and self.RewardsAvailable[0] == 1 and (slot.possible_types & RewardType.CHARACTER):
                 # This must be a character.
                 if self.verbose:
                     print('\tmust be a character')


### PR DESCRIPTION
…ains

When RewardsAvailable[0] == 1 but all planned characters were already assigned, the code would force a character assignment anyway. This caused get_random_available(exclude=non_planned_chars) to return an empty list, crashing with IndexError.

Added check for remaining_chars_needed >= 1 to only force character assignment when we actually still need planned characters.