### PR TITLE
Add configurable verbose flag to ruination_map

### DIFF
--- a/event/events.py
+++ b/event/events.py
@@ -242,7 +242,8 @@ class Events():
         party = [self.characters.DEFAULT_NAME[c] for c in characters_available]
 
         # Initialize ruination_map object
-        ruin_map = ruination_map(self.args, party)
+        # Use -debug flag to enable verbose output for map generation diagnostics
+        ruin_map = ruination_map(self.args, party, verbose=self.args.debug)
 
         # Build out the map & distribute characters
         # Note: reward_slots are updated automatically via shared object references (see generate_map_with_characters docstring)
@@ -257,9 +258,10 @@ class Events():
             self.shops.assign_dried_meats_ruination(non_veldt_shops)
 
         # Check state of reward_slots
-        print('REWARD STATE AFTER RUIN MAPPING:')
-        for slot in reward_slots:
-            print(slot.event.name(), slot.id, slot.type)
+        if self.args.debug:
+            print('REWARD STATE AFTER RUIN MAPPING:')
+            for slot in reward_slots:
+                print(slot.event.name(), slot.id, slot.type)
 
         # For safety (?) distribute any remaining rewards
         reward_slots = [slot for slot in reward_slots if slot.id is None]

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -424,7 +424,8 @@ class RuinationBranch(Network):
         return issues
 
     def finalize_map(self):
-        print('Closing branch...')
+        if self.verbose:
+            print('Closing branch...')
 
         self.ForceConnections(forced_connections)
 
@@ -1045,7 +1046,7 @@ class RuinationBranch(Network):
                   '\n\tDownstream nodes: ', downstream,
                   '\n\tAll entrances: ', all_entrances)
         hub_is_upstream = len([n for n in upstream if 'ruin_hub_' in str(n)]) > 0
-        if hub_is_upstream:
+        if hub_is_upstream and self.verbose:
             print('\tHub is upstream!')
         for node in upstream:
             room = self.rooms.get_room(node)
@@ -1207,9 +1208,11 @@ class RuinationBranch(Network):
 
 class ruination_map():
     # Class to organize data for mapping out ruination mode branches
-    verbose = True
 
-    def __init__(self, args, starting_party):
+    def __init__(self, args, starting_party, verbose=False):
+        # Verbose flag controls debug output throughout map generation
+        self.verbose = verbose
+
         # Instance attributes - each instance gets fresh state
         self.RewardsAvailable = [0, 0]   # [# possible characters, # possible espers]
         self.PARTY = list(starting_party)  # use character names in all caps


### PR DESCRIPTION
- Change ruination_map verbose from class attribute to instance parameter
- Default to False (production mode), enabled by -debug flag
- Guard remaining unguarded print statements:
  - "Hub is upstream!" in extend_branch_path_with_trapdoors
  - REWARD STATE prints in events.py ruination_mod
- Error/warning prints intentionally kept always-on for diagnostics