### PR TITLE
Fix Esper Mtn warp visibility and add Sealed Gate close animation

### DIFF
--- a/event/esper_mountain.py
+++ b/event/esper_mountain.py
@@ -31,6 +31,11 @@ class EsperMountain(Event):
             space.write(
                 field.ClearEventBit(event_bit.ESPER_MOUNTAIN_GATED),
             )
+        if self.args.ruination_mode:
+            # Set warp point NPC bit so it's visible initially (will be cleared when used)
+            space.write(
+                field.SetEventBit(npc_bit.ESPER_MTN_WARP_POINT),
+            )
 
     def mod(self):
         self.entrance_relm_npc_id = 0x1c
@@ -398,8 +403,8 @@ class EsperMountain(Event):
             "DO_WARP",
             # Mark terminus as used before warping
             field.SetEventBit(event_bit.ESPER_MTN_TERMINUS_USED),
-            # Set npc_bit to hide the warp point NPC on future visits
-            field.SetEventBit(npc_bit.ESPER_MTN_WARP_POINT),
+            # Clear npc_bit to hide the warp point NPC on future visits
+            field.ClearEventBit(npc_bit.ESPER_MTN_WARP_POINT),
             # Make warp point visually disappear now
             field.PlaySoundEffect(0x51),  # vanish sound
             field.DeleteEntity(warp_npc_entity),

--- a/event/sealed_gate.py
+++ b/event/sealed_gate.py
@@ -438,7 +438,38 @@ class SealedGate(Event):
                             field_entity.Move(direction.UP, 2)),
             field.Call(0xb38ac),  # lightning strike
             field.HideEntity(field_entity.PARTY0),
-            field.Pause(1),
+            field.Pause(0.5),
+
+            # Gate closes behind the player (reverse of opening animation)
+            field.PlaySoundEffect(165),  # gate rumble sound
+            field.ShakeScreen(intensity=3, permanent=1, layer1=True, layer2=True, layer3=True, sprite_layer=True),
+            field.Pause(0.5),
+
+            # Move gate NPCs back together (opposite of opening)
+            field.EntityAct(0x10, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+            field.EntityAct(0x12, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+            field.EntityAct(0x13, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.RIGHT, 1)),
+            field.EntityAct(0x11, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+            field.EntityAct(0x14, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+            field.EntityAct(0x15, False,
+                            field_entity.SetSpeed(field_entity.Speed.SLOWEST),
+                            field_entity.Move(direction.LEFT, 1)),
+
+            # Wait for gate to close
+            field.Pause(1.5),
+            field.StopScreenShake(),
+            field.Pause(0.5),
+
             field.FadeOutScreen(),
             field.FreeScreen(),
         ] + GoToSwitchyard(kt_enter_id)


### PR DESCRIPTION
Esper Mountain:
- Fix NPC bit logic: set bit on init (visible), clear on use (hidden)
- Add SetEventBit call in init_event_bits for ruination mode

Sealed Gate:
- Add gate closing animation after player enters KT
- Includes screen shake and rumble sound effect
- Gate NPCs move back together (reverse of opening animation)

https://claude.ai/code/session_01D11PubrcZ7HMaFXdWfzsVk