### PR TITLE
Fix: Disable airship warp to player location in ruination mode

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -1013,6 +1013,10 @@ class Maps():
             if d not in map_shuffle_airship_warp:
                 require_event_flags[4] = False
 
+        # In ruination mode, never warp the airship to the player's location
+        if self.args.ruination_mode:
+            require_event_flags[4] = False
+
         if require_event_flags.count(True) > 0:
             # Need to use different commands for world maps vs field maps.
             # Look for an existing event on this exit tile
@@ -1282,6 +1286,10 @@ class Maps():
             # Don't airship warp if only doing map shuffle
             if d not in map_shuffle_airship_warp:
                 require_event_flags[4] = False
+
+        # In ruination mode, never warp the airship to the player's location
+        if self.args.ruination_mode:
+            require_event_flags[4] = False
 
         # if self.doors.verbose:
         #    print('Writing shared event at ' + str(d) + ' (ref = ' + str(d_ref) + ')')


### PR DESCRIPTION
In dungeon crawl mode, when the player exits to a world map (like the Veldt for Gau's check), the airship is automatically warped to the player's location to prevent softlocks. This behavior should not apply to ruination mode since it breaks the intended gameplay flow.

Added checks in both exit handling locations in maps.py to skip the airship warp when ruination_mode is enabled.

https://claude.ai/code/session_01Jx11A7MifNm5Xc6ZWsDP7W