### PR TITLE
Fix Esper Mountain warp point visible before activation

### DIFF
--- a/event/esper_world.py
+++ b/event/esper_world.py
@@ -10,6 +10,16 @@ class EsperWorld(Event):
             field.ClearEventBit(npc_bit.ESPER_WORLD_MADONNA)  # 0x357
         )
 
+        if self.args.ruination_mode:
+            # Clear all warp point NPC bits to ensure they start hidden
+            # These bits control visibility of warp point NPCs in the Esper World
+            # and must be cleared at game start so warp points only appear after activation
+            from data.warps import AVAILABLE_NPC_BITS
+            for bit in AVAILABLE_NPC_BITS:
+                space.write(
+                    field.ClearEventBit(bit)
+                )
+
     def mod(self):
         self.map_outside = 0x0d9   # Esper world hub
         self.map_gate_cave = 0x0da   # Esper gate


### PR DESCRIPTION
In ruination mode, the warp point NPCs in the Esper World use NPC bits from AVAILABLE_NPC_BITS for visibility control. These bits were not being cleared at game start, causing some warp points (particularly Esper Mountain at bit 0x33c) to be visible before the player activates them at the corresponding save point.

The fix clears all AVAILABLE_NPC_BITS at game initialization in ruination mode, ensuring warp point NPCs start hidden and only appear after the player steps on the save point for the first time.

https://claude.ai/code/session_01C4t3CmQEybBPS6sJRdbf6h