### PR TITLE
Fix hub loop connections consuming last two exits

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -1143,8 +1143,9 @@ class RuinationBranch(Network):
 
         # === Connect to upstream/hub doors (forms loop) ===
         # GLOBAL PROTECTION: Loop connections don't add new exits to the branch.
-        # Only allow if the branch would still have exits after using this door.
-        if current_total_exits > 1:
+        # They consume TWO exits: the source door AND the target door in hub/upstream.
+        # Only allow if the branch would still have exits after using both doors.
+        if current_total_exits > 2:
             for h_id in hub_and_upstream:
                 h_room = self.rooms.get_room(h_id)
                 if h_room:


### PR DESCRIPTION
When connecting a downstream door to a hub/upstream door, BOTH doors are consumed (source AND target). The check was `> 1` but should be `> 2` to ensure at least one exit remains after using both.

Example: if level 2 has door 443 and hub has door 477, and these are the only two exits (current_total_exits = 2), connecting them together leaves 0 exits. The old check `2 > 1` passed, but we need `> 2`.

https://claude.ai/code/session_01SKycZMToB38nbgBkrN8GR4