### PR TITLE
Fix TypeError in get_valid_pit_targets: 'in <string>' requires string

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -993,7 +993,7 @@ class RuinationBranch(Network):
                 for node in path:
                     loop_rooms.add(node)
                     # Check if this node IS the pit_room or CONTAINS the pit_room (compound room)
-                    if node == pit_room.id or pit_room.id in str(node) or str(pit_room.id) in str(node):
+                    if node == pit_room.id or str(pit_room.id) in str(node):
                         found_pit_room = True
                         break
                 if found_pit_room:


### PR DESCRIPTION
The condition `pit_room.id in str(node)` was invalid because pit_room.id is an integer and the `in` operator for strings requires both operands to be strings. Removed the redundant buggy condition since `str(pit_room.id) in str(node)` already handles the compound room check correctly.

https://claude.ai/code/session_01AqqRS1ZcC2KsJvD7k68JQG