### PR TITLE
Document key/lock softlock fix: update ARCHIVE.md, TODO.md, CLAUDE.md

### DIFF
--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -142,6 +142,97 @@ A branch becomes **stuck** when:
 
 ---
 
+## Key/Lock Softlock Analysis & Fix (2026-02-10)
+
+### Problem
+
+The mapping algorithm applies keys when rooms are **connected** (during path building), but the player applies keys when rooms are **visited**. Since the player can explore rooms in any order, the algorithm's key ordering guarantee does not hold for the player. This can cause softlocks when a player enters a room (via a one-way pit) whose exits are all locked by keys found in other rooms they haven't visited yet.
+
+The risk directly applies to **pit (one-way) entrances**, because players cannot return through pits. However, it can indirectly apply to doors as well, if the connection to the door results in a downstream node whose only exit was once locked.
+
+### Catalog of All Keyed Rooms in RUIN_ROOM_SETS
+
+#### Character-Keyed Locks
+
+| Room | Area | Free Exits | Locked Exits | Key |
+|------|------|-----------|-------------|-----|
+| `ruin-thamasa` | VeldtCave | 2 doors, 2 pits | trap 2054 (STRAGO) | Character |
+| `ruin-whelk` | Narshe | 2 doors | door 1155 (TERRA) | Character |
+| `ruin-zozo` | Zozo | 5 doors | door 4608 (TERRA), key 'zr1' (CYAN) | Character |
+
+#### Self-Unlocking Rooms (key provided by same room -- no softlock risk)
+
+| Room | Area | Free Exits | Lock | Key Source |
+|------|------|-----------|------|-----------|
+| 216 | PhantomTrain | 1 door | doors 493/494 (pt1) | Self (pt1) |
+| 472 | VeldtCave | 1 door | door 989 (vc1) | Self (vc1) |
+| 435 | Doma | 1 door | doors 865/866 (cd3) | Self (cd3) |
+| `ruin-daryl` | DarylsTomb | 1 door | door 1563 (dtboss) | Self (dtboss) |
+
+#### Non-Character Locks with Free Exits (key from other room -- moderate risk)
+
+These rooms always have at least one free exit. The player may be trapped if the last remaining exit in the downstream node is the initially-locked door, or if the locked door is physically impassible without the key (e.g. door 618 in Zozo).
+
+| Room | Area | Free Exits | Locked Exits | Key Source |
+|------|------|-----------|-------------|-----------|
+| 202 | PhantomTrain | 9 doors | trap 2068 (pt2) | Room 212 |
+| 383 | DarylsTomb | 1 door | door 1512 (dt1) | Room 392 |
+| 429 | Doma | 1 door | trap 2070 (cd1+cd2) | Rooms 423, 427 |
+| 531 | AncientCastle | 1 door | door 1106 (ac2) | Room 528 |
+| `296r` | Zozo | 2 doors | door 618 (zr1) | `ruin-zozo` + CYAN |
+
+#### Key-Providing Rooms (no softlock risk -- these rooms give keys, not locks)
+
+| Room | Area | Keys Provided | Free Exits |
+|------|------|-------------|-----------|
+| 212 | PhantomTrain | pt2 | 1 door |
+| 389 | DarylsTomb | dt2 | 1 door |
+| 390 | DarylsTomb | dt3 | 2 doors, 1 trap, 1 pit |
+| 392 | DarylsTomb | dt1 | 1 door |
+| `301r` | Zozo | clock1 | 3 doors |
+| `306r` | Zozo | clock2 | 1 door |
+| 299 | ZozoTower | clock5 | 2 doors |
+| `303a`/`303b` | ZozoTower | clock3 | 1 door + trap/pit |
+| 304 | ZozoTower | clock4 | 2 doors |
+| 423 | Doma | cd1 | 1 trap, 1 pit |
+| 427 | Doma | cd2 | 1 trap, 1 pit |
+| 528 | AncientCastle | ac2 | 4 doors |
+
+#### HIGH RISK -- All Exits Locked, Key From Other Rooms
+
+| Room | Area | Free Exits | Locked Exits | Key Sources |
+|------|------|-----------|-------------|------------|
+| **391** | **DarylsTomb** | **0 doors, 0 traps, 1 pit (entrance only)** | **door 795 (dt2), trap 2060 (dt3)** | **Room 389 (dt2), Room 390 (dt3)** |
+
+### Room 391 Softlock Scenario
+
+Room 391 is the right-half of the physical map that also contains room 390. It is the only room in ruination mode with zero initially-free exits where all exits are locked by non-character keys from other rooms. The softlock scenario:
+
+1. During `extend_branch_path`, rooms 389 and 390 are connected to the hub. Their keys (dt2, dt3) are applied via `apply_key()`, promoting room 391's locked elements to free: door 795 and trap 2060.
+2. Room 391 is now in the upstream and downstream of the hub, due to the forced connection. The algorithm closes the loop, thinking door 795 is now available.
+3. Subsequently, `extend_branch_path` connects another trap in the hub to a pit-in, door-out room, creating a downstream node with one door.
+4. `get_valid_door_targets_v2` evaluates door 795 as a target. It closes the loop back to the hub, and is deemed valid.
+5. Algorithm connects the downstream node door to door 795. Valid from the algorithm's perspective.
+6. Player enters the hub, falls through a trap to the downstream room, walks through the door into room 391.
+7. The player hasn't visited rooms 389/390 yet. Keys dt2 and dt3 haven't been obtained. Room 391's exits are still locked. **SOFTLOCK.**
+
+### Solution: Track "Initially Locked" Exits (implemented 2026-02-11)
+
+When `apply_key()` unlocks an element (moves it from locks to free), it is recorded in `self.initially_locked_exits` (a set on the Network class in `data/walks.py`). The algorithm then enforces these rules:
+
+1. **`apply_key()`** (`data/walks.py`): When a door or trap is unlocked, adds it to `self.initially_locked_exits`.
+2. **`get_valid_door_targets_v2`**: Excludes doors in `initially_locked_exits` from the candidate target list (they can't serve as entrances the player can use without keys).
+3. **`get_valid_pit_targets_v2` Rule A1**: After checking `target_exits > 0`, requires at least one originally-free exit (not in `initially_locked_exits`). Rooms with only key-unlocked exits are skipped.
+4. **`finalize_map` step 1**: When selecting target rooms for trap-to-pit balancing, skips rooms with no originally-free exits.
+5. **`extend_branch_path` STEP 2**: When the active node is downstream (`active_level > 0`), initially-locked doors and traps are excluded from available exits. From the hub, they remain available since the player can visit key-providing rooms first.
+
+This correctly handles all cases:
+- Self-unlocking rooms (216, 472, 435, ruin-daryl) always have >= 1 free exit
+- Room 391's door 795 is rejected as a door target since it's initially-locked
+- Room 391 is rejected as a pit target since it has 0 originally-free exits
+
+---
+
 ## Ruination Mode - finalize_map Debug Patterns (2026-02-09)
 
 ### Invariant: Hub must always retain entrances

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Event-specific modifications go in their respective event files (e.g., `event/bu
   - `get_valid_door_targets_v2` / `get_valid_pit_targets_v2`: Connection validation (hub entrance invariants)
   - `finalize_map`: Steps 1-6 close all connections; see ARCHIVE.md for detailed reference
   - All `room_data` lookups in reserve area searches must filter by `self.protected`
+- **`initially_locked_exits`** (set on Network in `data/walks.py`): Tracks doors/traps unlocked by `apply_key()`. These exits are excluded as connection targets and from downstream available exits because the player may not have the key yet. See ARCHIVE.md "Key/Lock Softlock Analysis" for full details.
 
 ### 8. Finding Map IDs by Name
 1. Search `data/map_exit_extra.py` for location name in `exit_data`

--- a/event/TODO.md
+++ b/event/TODO.md
@@ -1,103 +1,16 @@
 # Todo list for Claude (-ruin mode updates)
 
-## Key/Lock Softlock Analysis (2026-02-10)
+## Key/Lock Softlock Fix (2026-02-11)
 
-### Summary
+✅ **FIXED** - Track "initially locked" exits to prevent softlocks from key ordering mismatch. The algorithm applies keys at connection time, but the player applies them at visit time. Rooms whose exits are all key-unlocked (e.g., Room 391 in Daryl's Tomb) could trap a player entering via pit before obtaining keys. See ARCHIVE.md for full analysis, room catalog, and implementation details.
 
-The mapping algorithm applies keys when rooms are **connected** (during path building), but the player applies keys when rooms are **visited**. Since the player can explore rooms in any order, the algorithm's key ordering guarantee does not hold for the player. This can cause softlocks when a player enters a room (via a one-way pit) whose exits are all locked by keys found in other rooms they haven't visited yet.
+**Implementation**: `initially_locked_exits` set on Network class (`data/walks.py`), checked in `apply_key()`, `get_valid_door_targets_v2`, `get_valid_pit_targets_v2`, `extend_branch_path`, and `finalize_map` step 1.
 
-The risk directly applies to **pit (one-way) entrances**, because players cannot return through pits.  However, it can indirectly apply to doors as well, if the connection to the door results in a downstream node whose only exit was once locked. 
-
-### Catalog of All Keyed Rooms in RUIN_ROOM_SETS
-
-#### Character-Keyed Locks (consider addressing by changing the particular 'character-gating' logic)
-
-| Room | Area | Free Exits | Locked Exits | Key |
-|------|------|-----------|-------------|-----|
-| `ruin-thamasa` | VeldtCave | 2 doors, 2 pits | trap 2054 (STRAGO) | Character |
-| `ruin-whelk` | Narshe | 2 doors | door 1155 (TERRA) | Character |
-| `ruin-zozo` | Zozo | 5 doors | door 4608 (TERRA), key 'zr1' (CYAN) | Character |
-
-#### Self-Unlocking Rooms (key provided by same room -- no softlock risk)
-
-| Room | Area | Free Exits | Lock | Key Source |
-|------|------|-----------|------|-----------|
-| 216 | PhantomTrain | 1 door | doors 493/494 (pt1) | Self (pt1) |
-| 472 | VeldtCave | 1 door | door 989 (vc1) | Self (vc1) |
-| 435 | Doma | 1 door | doors 865/866 (cd3) | Self (cd3) |
-| `ruin-daryl` | DarylsTomb | 1 door | door 1563 (dtboss) | Self (dtboss) |
-
-#### Non-Character Locks with Free Exits (key from other room -- moderate risk)
-
-These rooms always have at least one free exit.  The player may be trapped if the last remaining exit in the downstream node is the initially-locked door, or if the locked door is physically impassible without the key (e.g. door 618 in Zozo). 
-
-| Room | Area | Free Exits | Locked Exits | Key Source |
-|------|------|-----------|-------------|-----------|
-| 202 | PhantomTrain | 9 doors | trap 2068 (pt2) | Room 212 |
-| 383 | DarylsTomb | 1 door | door 1512 (dt1) | Room 392 |
-| 429 | Doma | 1 door | trap 2070 (cd1+cd2) | Rooms 423, 427 |
-| 531 | AncientCastle | 1 door | door 1106 (ac2) | Room 528 |
-| `296r` | Zozo | 2 doors | door 618 (zr1) | `ruin-zozo` + CYAN |
-
-#### Key-Providing Rooms (no softlock risk -- these rooms give keys, not locks)
-
-| Room | Area | Keys Provided | Free Exits |
-|------|------|-------------|-----------|
-| 212 | PhantomTrain | pt2 | 1 door |
-| 389 | DarylsTomb | dt2 | 1 door |
-| 390 | DarylsTomb | dt3 | 2 doors, 1 trap, 1 pit |
-| 392 | DarylsTomb | dt1 | 1 door |
-| `301r` | Zozo | clock1 | 3 doors |
-| `306r` | Zozo | clock2 | 1 door |
-| 299 | ZozoTower | clock5 | 2 doors |
-| `303a`/`303b` | ZozoTower | clock3 | 1 door + trap/pit |
-| 304 | ZozoTower | clock4 | 2 doors |
-| 423 | Doma | cd1 | 1 trap, 1 pit |
-| 427 | Doma | cd2 | 1 trap, 1 pit |
-| 528 | AncientCastle | ac2 | 4 doors |
-
-#### HIGH RISK -- All Exits Locked, Key From Other Rooms
-
-| Room | Area | Free Exits | Locked Exits | Key Sources |
-|------|------|-----------|-------------|------------|
-| **391** | **DarylsTomb** | **0 doors, 0 traps, 1 pit (entrance only)** | **door 795 (dt2), trap 2060 (dt3)** | **Room 389 (dt2), Room 390 (dt3)** |
-
-### Special considerations for Room 391
-
-Room 391 is the right-half of the physical map that also contains room 390.  It is only room in ruination mode with zero initially-free exits where all exits are locked by non-character keys from other rooms.  However, its pit and locked trap are both forced connections that create a bi-directional connection to room 390, **as long as** room 390 is entered first.  The danger with room 391 is as follows:
-
-1. During `extend_branch_path`, rooms 389 and 390 are connected to the hub. Their keys (dt2, dt3) are applied via `apply_key()`, which promotes room 391's locked elements to free: door 795 and trap 2060.
-2. Room 391 is now in the upstream and downstream of the hub, due to the forced connection.  The algorithm closes the loop, thinking door 795 is now available to the hub. 
-3. Subsequently, `extend_branch_path` connects another trap in the hub to a pit-in, door-out room, creating a downstream node with one door.  
-4. `get_valid_pit_targets_v2` evaluates door 795 as a target.  It closes the loop back to the hub, and is deemed valid.
-5. Algorithm connects the downstream node door to door 795.  Valid from the algorithm's perspective, as long as other hub exits are available.  The forced connections already exist, closing the loop back to the hub.
-6. Player enters the hub. They enter a trap (leading to the dounstream pido room). Player walks through the door into room 391.
-7. The player hasn't visited rooms 389/390 yet. In the player's game state, dt2 and dt3 haven't been obtained. Room 391's exits are still locked, and the player cannot return to the hub. **SOFTLOCK.**
-
-### Proposed Solution: Track "Initially Locked" Exits
-
-When `apply_key()` unlocks an element (moves it from locks to free), record it in a set `initially_locked_exits`. When evaluating connections, DO NOT connect to initially locked doors as entrances: they must be used as exits only.  When evaluating traps, require that the target room has at least one exit that was **originally free** (not just unlocked by key application during path building).
-
-1. Add `self.initially_locked_exits = set()` to the Branch class.
-2. In `apply_key()` (walks.py:135), when an element is unlocked and added to the room, also add it to `self.initially_locked_exits`.
-3. In `get_valid_pit_targets_v2` Rule A1 (unconnected room check), add after the `target_exits > 0` check:
-   ```python
-   originally_free_exits = (
-       len([d for d in room.doors if d not in self.protected
-            and d not in self.initially_locked_exits])
-       + len([t for t in room.traps if t not in self.protected
-              and t not in self.initially_locked_exits])
-   )
-   if originally_free_exits == 0:
-       continue  # All exits were key-unlocked; player could be trapped
-   ```
-4. In `get_valid_door_targets_v2` ... do not include doors in initially_locked_exits as valid targets.  
-5. Apply the same check in finalize_map steps (1) and (3) when pairing traps with pits.
-
-This correctly handles all cases:
-- Self-unlocking rooms (216, 472, 435, ruin-daryl) always have >= 1 free exit
-- Room 391, door 795 is rejected as a door target since it must be key-unlocked
-
+❌ **TODO** - Review the 3 character-gated exits and decide how to handle them:
+  - `ruin-thamasa`: trap 2054 locked by STRAGO
+  - `ruin-whelk`: door 1155 locked by TERRA
+  - `ruin-zozo`: door 4608 locked by TERRA, key 'zr1' locked by CYAN
+  - These are currently treated as initially-locked by the fix. Consider whether the character-gating logic itself should be changed (e.g., remove the gate, change to a different mechanism, or keep as-is since each room has free exits).
 
 ---
 


### PR DESCRIPTION
- ARCHIVE.md: Add full key/lock softlock analysis including room catalog, Room 391 scenario, and implementation details for initially_locked_exits
- TODO.md: Simplify key/lock section to completed summary, add TODO for reviewing character-gated exits (STRAGO, TERRA, CYAN locks)
- CLAUDE.md: Add initially_locked_exits to Key Module Locations (#7)

https://claude.ai/code/session_01Cbnb7WbMBf6E9EKd3293bD