### PR TITLE
Fix party slot collision and count overflow with away parties

### DIFF
--- a/event/narshe_wob.py
+++ b/event/narshe_wob.py
@@ -194,9 +194,10 @@ class NarsheWOB(Event):
         space = Write(Bank.CA, remove_available_src, "Remove available characters from parties (preserve away)")
         remove_available_addr = space.start_address
 
-        src_party1 = [
-            field.SetPartyMap(1, school_map_id),  # Set party 1 on this map
-            field.SetParty(1),  # Make party 1 the active party
+        # Position subroutines: position PARTY0 at each location.
+        # These do NOT include SetParty/SetPartyMap - the caller handles those
+        # dynamically based on which party slots are free.
+        src_pos_center = [
             field.RefreshEntities(),
             field.UpdatePartyLeader(),
             field.EntityAct(field_entity.PARTY0, True,
@@ -207,11 +208,10 @@ class NarsheWOB(Event):
             field.UpdatePartyLeader(),
             field.Return()
         ]
-        space = Write(Bank.CA, src_party1, "Place party 1 reform school")
-        place_party_1_addr = space.start_address
+        space = Write(Bank.CA, src_pos_center, "Position party at center (reform school)")
+        pos_center_addr = space.start_address
 
-        src_party2 = [
-            field.SetParty(2),  # Make party 2 the active party
+        src_pos_upper_right = [
             field.RefreshEntities(),
             field.UpdatePartyLeader(),
             field.EntityAct(field_entity.PARTY0, True,
@@ -222,11 +222,10 @@ class NarsheWOB(Event):
             field.UpdatePartyLeader(),
             field.Return()
         ]
-        space = Write(Bank.CA, src_party2, "Place party 2 reform school")
-        place_party_2_addr = space.start_address
+        space = Write(Bank.CA, src_pos_upper_right, "Position party at upper-right (reform school)")
+        pos_upper_right_addr = space.start_address
 
-        src_party3 = [
-            field.SetParty(3),  # Make party 3 the active party
+        src_pos_lower_right = [
             field.RefreshEntities(),
             field.UpdatePartyLeader(),
             field.EntityAct(field_entity.PARTY0, True,
@@ -237,50 +236,126 @@ class NarsheWOB(Event):
             field.UpdatePartyLeader(),
             field.Return()
         ]
-        space = Write(Bank.CA, src_party3, "Place party 3 reform school")
-        place_party_3_addr = space.start_address
+        space = Write(Bank.CA, src_pos_lower_right, "Position party at lower-right (reform school)")
+        pos_lower_right_addr = space.start_address
 
         reform_src = [
             "START_OVER",
-            field.DialogBranch(reform_id, dest1 = "REFORM", dest2 = 0xc359d, dest3 = 0xc351e, dest4 = field.RETURN),
+            field.DialogBranch(reform_id, dest1="REFORM", dest2=0xc359d, dest3=0xc351e, dest4=field.RETURN),
+
+            # === Determine max new parties (3 - away_count) capped by CHARACTERS_AVAILABLE ===
             "REFORM",
+            # Check away parties to determine free slot count
+            field.BranchIfEventBitSet(event_bit.PARTY_1_AWAY, "CHECK_P1_AWAY"),
+            field.BranchIfEventBitSet(event_bit.PARTY_2_AWAY, "CHECK_P2_AWAY_NO_P1"),
+            field.BranchIfEventBitSet(event_bit.PARTY_3_AWAY, "MAX_2_NEW"),
+            field.Branch("MAX_3_NEW"),
+
+            "CHECK_P1_AWAY",  # P1 is away
+            field.BranchIfEventBitSet(event_bit.PARTY_2_AWAY, "MAX_1_NEW"),  # P1+P2 away
+            field.BranchIfEventBitSet(event_bit.PARTY_3_AWAY, "MAX_1_NEW"),  # P1+P3 away
+            field.Branch("MAX_2_NEW"),  # only P1 away
+
+            "CHECK_P2_AWAY_NO_P1",  # P2 away, P1 not
+            field.BranchIfEventBitSet(event_bit.PARTY_3_AWAY, "MAX_1_NEW"),  # P2+P3 away
+            # fallthrough: only P2 away
+
+            "MAX_2_NEW",  # exactly 1 away -> at most 2 new parties
             field.BranchIfEventWordLess(event_word.CHARACTERS_AVAILABLE, 2, "1_PARTY"),
-            field.BranchIfEventWordLess(event_word.CHARACTERS_AVAILABLE, 3, "NOT_3_PARTIES"),
-            field.DialogBranch(reform_id_3, dest1="1_PARTY", dest2="2_PARTIES", dest3="3_PARTIES", dest4=field.RETURN),
-            "NOT_3_PARTIES",
             field.DialogBranch(reform_id_2, dest1="1_PARTY", dest2="2_PARTIES", dest3=field.RETURN),
+
+            "MAX_1_NEW",  # 2 parties away -> force 1 new party
+            field.Branch("1_PARTY"),
+
+            "MAX_3_NEW",  # 0 away -> up to 3 new parties (original logic)
+            field.BranchIfEventWordLess(event_word.CHARACTERS_AVAILABLE, 2, "1_PARTY"),
+            field.BranchIfEventWordLess(event_word.CHARACTERS_AVAILABLE, 3, "MAX_3_NOT_ENOUGH_FOR_3"),
+            field.DialogBranch(reform_id_3, dest1="1_PARTY", dest2="2_PARTIES", dest3="3_PARTIES", dest4=field.RETURN),
+            "MAX_3_NOT_ENOUGH_FOR_3",
+            field.DialogBranch(reform_id_2, dest1="1_PARTY", dest2="2_PARTIES", dest3=field.RETURN),
+
+            # === 1 PARTY: select 1 party, remap to first free slot ===
             "1_PARTY",
-            field.Call(remove_available_addr),  # only remove non-away characters
+            field.Call(remove_available_addr),
             field.Call(REFRESH_CHARACTERS_AND_SELECT_PARTY),
-            # Place on map & load map
-            field.Call(place_party_1_addr),
+            field.RemapPartiesToFreeSlots(),
+            # Determine first free slot for SetPartyMap/SetParty
+            field.BranchIfEventBitClear(event_bit.PARTY_1_AWAY, "1P_SLOT1"),
+            field.BranchIfEventBitClear(event_bit.PARTY_2_AWAY, "1P_SLOT2"),
+            # P1 and P2 both away -> use slot 3
+            field.SetPartyMap(3, school_map_id),
+            field.SetParty(3),
+            field.Branch("1P_PLACE"),
+            "1P_SLOT2",
+            field.SetPartyMap(2, school_map_id),
+            field.SetParty(2),
+            field.Branch("1P_PLACE"),
+            "1P_SLOT1",
+            field.SetPartyMap(1, school_map_id),
+            field.SetParty(1),
+            # fallthrough
+            "1P_PLACE",
+            field.Call(pos_center_addr),
             field.FadeInScreen(),
             field.WaitForFade(),
-            field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),  # Disable y-party switching
+            field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
             field.Return(),
+
+            # === 2 PARTIES: select 2 parties, remap to free slots ===
             "2_PARTIES",
-            field.Call(remove_available_addr),  # only remove non-away characters
+            field.Call(remove_available_addr),
             field.Call(REFRESH_CHARACTERS_AND_SELECT_TWO_PARTIES),
-            # Place on map & load map
-            field.SetPartyMap(1, school_map_id),  # Set party 1 on this map
-            field.SetPartyMap(2, school_map_id),  # Set party 2 on this map
-            field.Call(place_party_2_addr),
-            field.Call(place_party_1_addr),
+            field.RemapPartiesToFreeSlots(),
+            # Branch based on which party is away for correct slot assignment
+            field.BranchIfEventBitSet(event_bit.PARTY_1_AWAY, "2P_P1_AWAY"),
+            field.BranchIfEventBitSet(event_bit.PARTY_2_AWAY, "2P_P2_AWAY"),
+            # P3 away or none -> free slots 1, 2
+            field.SetPartyMap(1, school_map_id),
+            field.SetPartyMap(2, school_map_id),
+            field.SetParty(2),
+            field.Call(pos_upper_right_addr),
+            field.SetParty(1),
+            field.Call(pos_center_addr),
+            field.Branch("2P_FINISH"),
+
+            "2P_P1_AWAY",  # P1 away -> free slots 2, 3
+            field.SetPartyMap(2, school_map_id),
+            field.SetPartyMap(3, school_map_id),
+            field.SetParty(3),
+            field.Call(pos_upper_right_addr),
+            field.SetParty(2),
+            field.Call(pos_center_addr),
+            field.Branch("2P_FINISH"),
+
+            "2P_P2_AWAY",  # P2 away -> free slots 1, 3
+            field.SetPartyMap(1, school_map_id),
+            field.SetPartyMap(3, school_map_id),
+            field.SetParty(3),
+            field.Call(pos_upper_right_addr),
+            field.SetParty(1),
+            field.Call(pos_center_addr),
+            # fallthrough
+
+            "2P_FINISH",
             field.FadeInScreen(),
             field.WaitForFade(),
             field.SetEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
             field.FreeMovement(),
             field.Return(),
+
+            # === 3 PARTIES (only reachable when 0 away - no remap needed) ===
             "3_PARTIES",
-            field.Call(remove_available_addr),  # only remove non-away characters
+            field.Call(remove_available_addr),
             field.Call(REFRESH_CHARACTERS_AND_SELECT_THREE_PARTIES),
-            # Place on map & load map
-            field.SetPartyMap(1, school_map_id),  # Set party 1 on this map
-            field.SetPartyMap(2, school_map_id),  # Set party 2 on this map
-            field.SetPartyMap(3, school_map_id),  # Set party 3 on this map
-            field.Call(place_party_3_addr),
-            field.Call(place_party_2_addr),
-            field.Call(place_party_1_addr),
+            field.SetPartyMap(1, school_map_id),
+            field.SetPartyMap(2, school_map_id),
+            field.SetPartyMap(3, school_map_id),
+            field.SetParty(3),
+            field.Call(pos_lower_right_addr),
+            field.SetParty(2),
+            field.Call(pos_upper_right_addr),
+            field.SetParty(1),
+            field.Call(pos_center_addr),
             field.FadeInScreen(),
             field.WaitForFade(),
             field.SetEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),

--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -615,3 +615,116 @@ class RestoreActivePartyAvailable(_Instruction):
 
         RestoreActivePartyAvailable.__init__ = lambda self: super().__init__(opcode)
         self.__init__()
+
+class RemapPartiesToFreeSlots(_Instruction):
+    """After SelectParties assigns characters to party slots 1..count,
+    remaps those assignments to the actual free slots (not occupied by away parties).
+
+    Only modifies characters with character_available set (non-away characters).
+    When no parties are away, this is a no-op (maps 1->1, 2->2, 3->3).
+
+    Uses direct page scratch $e8-$eb during execution."""
+    def __init__(self):
+        import data.event_bit as event_bit
+        from constants.entities import CHARACTER_COUNT
+
+        character_party_start = 0x1850
+        char_available_addr = event_bit.address(event_bit.character_available(0))  # 0x1ede
+        party_away_byte = event_bit.address(event_bit.PARTY_1_AWAY)  # 0x1e9b
+
+        src = [
+            # Step 1: Build free_slots mapping at DP $e8..$ea
+            # free_slots[i] = party mask for the (i+1)th free slot
+            # X tracks the index into the free_slots array
+
+            asm.LDA(party_away_byte, asm.ABS),  # load away byte
+            asm.STA(0xeb, asm.DIR),              # save for later checks
+            asm.LDX(0x0000, asm.IMM16),          # free_slot_index = 0
+
+            # Check party 1 (away bit 5 = mask 0x20)
+            asm.AND(0x20, asm.IMM8),             # test P1 away
+            asm.BNE("SKIP_P1"),
+            asm.LDA(0x01, asm.IMM8),             # party 1 mask
+            asm.STA(0xe8, asm.DIR_X),            # free_slots[idx] = 0x01
+            asm.INX(),
+            "SKIP_P1",
+
+            # Check party 2 (away bit 6 = mask 0x40)
+            asm.LDA(0xeb, asm.DIR),              # reload away byte
+            asm.AND(0x40, asm.IMM8),             # test P2 away
+            asm.BNE("SKIP_P2"),
+            asm.LDA(0x02, asm.IMM8),             # party 2 mask
+            asm.STA(0xe8, asm.DIR_X),            # free_slots[idx] = 0x02
+            asm.INX(),
+            "SKIP_P2",
+
+            # Check party 3 (away bit 7 = mask 0x80)
+            asm.LDA(0xeb, asm.DIR),              # reload away byte
+            asm.AND(0x80, asm.IMM8),             # test P3 away
+            asm.BNE("SKIP_P3"),
+            asm.LDA(0x04, asm.IMM8),             # party 3 mask
+            asm.STA(0xe8, asm.DIR_X),            # free_slots[idx] = 0x04
+            "SKIP_P3",
+
+            # Step 2: Remap characters' party assignments
+            # For each character: if character_available AND party != 0,
+            # remap their party mask using free_slots[]
+            asm.LDX(0x0000, asm.IMM16),          # character index
+
+            "CHAR_LOOP",
+            asm.PHX(),                            # save char index
+            asm.TDC(),                            # clear A (both bytes) for clean $BAED call
+            asm.TXA(),                            # A = char index
+            asm.JSR(0xbaed, asm.ABS),             # X = char mod 8, Y = char // 8
+            asm.LDA(c0.power_of_two_table, asm.LNG_X),  # bit mask
+            asm.AND(char_available_addr, asm.ABS_Y),     # test character_available
+            asm.BEQ("CHAR_NEXT"),                 # not available -> skip (PLX at CHAR_NEXT)
+
+            # Character is available. Restore char index and check party assignment.
+            asm.PLX(),                            # restore char index
+            asm.LDA(character_party_start, asm.ABS_X),  # load party assignment
+            asm.BEQ("CHAR_NEXT_NO_PLX"),          # 0 = unassigned, skip
+
+            # Remap: check which SelectParties slot and replace with free_slots[]
+            asm.CMP(0x01, asm.IMM8),
+            asm.BNE("NOT_SLOT1"),
+            asm.LDA(0xe8, asm.DIR),               # free_slots[0]
+            asm.BRA("STORE_REMAP"),
+
+            "NOT_SLOT1",
+            asm.CMP(0x02, asm.IMM8),
+            asm.BNE("NOT_SLOT2"),
+            asm.LDA(0xe9, asm.DIR),               # free_slots[1]
+            asm.BRA("STORE_REMAP"),
+
+            "NOT_SLOT2",
+            # Must be 0x04 (party 3)
+            asm.LDA(0xea, asm.DIR),               # free_slots[2]
+
+            "STORE_REMAP",
+            asm.STA(character_party_start, asm.ABS_X),  # write remapped party
+
+            "CHAR_NEXT_NO_PLX",
+            asm.INX(),
+            asm.CPX(CHARACTER_COUNT, asm.IMM16),
+            asm.BNE("CHAR_LOOP"),
+            asm.BRA("DONE"),
+
+            "CHAR_NEXT",
+            asm.PLX(),                            # restore char index
+            asm.INX(),
+            asm.CPX(CHARACTER_COUNT, asm.IMM16),
+            asm.BNE("CHAR_LOOP"),
+
+            "DONE",
+            asm.LDA(0x01, asm.IMM8),             # command size = 1 (opcode only)
+            asm.JMP(0x9b5c, asm.ABS),            # advance to next event command
+        ]
+        space = Write(Bank.C0, src, "custom remap parties to free slots")
+        address = space.start_address
+
+        opcode = 0x8c
+        _set_opcode_address(opcode, address)
+
+        RemapPartiesToFreeSlots.__init__ = lambda self: super().__init__(opcode)
+        self.__init__()


### PR DESCRIPTION
Two bugs in ruination party reform when parties are away in branches:

1. Party slot collision: SelectParties always assigns to slots 1..count, overwriting $1850 mappings for away parties in those slots. Added RemapPartiesToFreeSlots custom ASM instruction (opcode 0x8c) that remaps new party assignments to the first N free slots by reading PARTY_N_AWAY bits, building a free-slot mapping, and updating $1850 only for characters with character_available set.

2. Party count overflow: reform dialog only checked CHARACTERS_AVAILABLE to determine max parties, ignoring occupied slots. Now counts away parties first (via PARTY_1/2/3_AWAY event bits) and caps max new parties at 3 - away_count before checking character count.

Also restructured placement subroutines to be position-only (no hardcoded slot), with event-script branching to call correct SetPartyMap/SetParty based on which slots are actually free.

https://claude.ai/code/session_01CcRWubBUMGKGtqSgAdi64r