### PR TITLE
Fix AttributeError in RecruitAndSelectParty: use correct args attribute

### DIFF
--- a/instruction/field/instructions.py
+++ b/instruction/field/instructions.py
@@ -58,7 +58,7 @@ def RecruitAndSelectParty(character):
     from instruction.field.custom import RecruitCharacter
     from instruction.field.functions import REFRESH_CHARACTERS_AND_SELECT_PARTY
     import args as _args
-    if _args.args.ruin:
+    if _args.ruination_mode is not None:
         from instruction.field.custom import SetupBranchPartySelect, FinalizeBranchPartySelect
         return (RecruitCharacter(character),
                 SetupBranchPartySelect(character),


### PR DESCRIPTION
The args module sets parsed arguments as module-level attributes, so access should be _args.ruination_mode, not _args.args.ruin. The flag name is also "ruination_mode" (not "ruin") and should be checked with "is not None" since it can be None or a string value like "custom".

https://claude.ai/code/session_01GRs2m4H2xE133dfQAYVTre