### PR TITLE
Fix args.ruin AttributeError in 5 event files

### DIFF
--- a/event/baren_falls.py
+++ b/event/baren_falls.py
@@ -124,7 +124,7 @@ class BarenFalls(Event):
             field.Branch(space.end_address + 1), # skip nop
         )
 
-        if self.args.ruin:
+        if self.args.ruination_mode is not None:
             branch_refresh_src = [
                 field.SetupBranchPartySelect(character),
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),

--- a/event/floating_continent.py
+++ b/event/floating_continent.py
@@ -193,7 +193,7 @@ class FloatingContinent(Event):
 
         space = Reserve(0xad9b5, 0xad9b7, "floating continent down with the empire dialog", field.NOP())
 
-        if self.args.ruin:
+        if self.args.ruination_mode is not None:
             branch_refresh_src = [
                 field.SetupBranchPartySelect(character),
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),

--- a/event/lete_river.py
+++ b/event/lete_river.py
@@ -342,7 +342,7 @@ class LeteRiver(Event):
         space = Reserve(0xb0920, 0xb0920, "lete river sabin floats away")
         space.write(character)
 
-        if self.args.ruin:
+        if self.args.ruination_mode is not None:
             branch_refresh_src = [
                 field.SetupBranchPartySelect(character),
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),

--- a/event/lone_wolf.py
+++ b/event/lone_wolf.py
@@ -119,7 +119,7 @@ class LoneWolf(Event):
             field.Branch(space.end_address + 1), # skip nops
         )
 
-        if self.args.ruin:
+        if self.args.ruination_mode is not None:
             branch_refresh_src = [
                 field.SetupBranchPartySelect(character),
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),

--- a/event/mt_kolts.py
+++ b/event/mt_kolts.py
@@ -258,7 +258,7 @@ class MtKolts(Event):
         space = Reserve(0xa832b, 0xa832c, "mt kolts pause after vargas battle", field.NOP())
         space = Reserve(0xa8353, 0xa8353, "mt kolts pause before locke approaches sabin", field.NOP())
 
-        if self.args.ruin:
+        if self.args.ruination_mode is not None:
             src = [
                 field.SetupBranchPartySelect(character),
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),


### PR DESCRIPTION
Same bug as instructions.py: the flag is "ruination_mode" not "ruin". Fixed in lone_wolf.py, lete_river.py, mt_kolts.py, baren_falls.py, and floating_continent.py.

https://claude.ai/code/session_01GRs2m4H2xE133dfQAYVTre