### PR TITLE
Fix party formation: $1850 byte masking in remap + missing FreeMovement

### DIFF
--- a/event/narshe_wob.py
+++ b/event/narshe_wob.py
@@ -299,6 +299,7 @@ class NarsheWOB(Event):
             field.FadeInScreen(),
             field.WaitForFade(),
             field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            field.FreeMovement(),
             field.Return(),
 
             # === 2 PARTIES: select 2 parties, remap to free slots ===

--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -687,7 +687,11 @@ class RemapPartiesToFreeSlots(_Instruction):
 
             # Character is available. Restore char index and check party assignment.
             asm.PLX(),                            # restore char index
-            asm.LDA(character_party_start, asm.ABS_X),  # load party assignment
+            asm.LDA(character_party_start, asm.ABS_X),  # load party assignment byte
+            asm.AND(0xf8, asm.IMM8),             # isolate non-party bits (enabled flag, etc.)
+            asm.STA(0xee, asm.DIR),              # save non-party bits for STORE_REMAP
+            asm.LDA(character_party_start, asm.ABS_X),  # reload full byte
+            asm.AND(0x07, asm.IMM8),             # isolate party bits (1, 2, or 3)
             asm.BEQ("CHAR_NEXT_NO_PLX"),          # 0 = unassigned, skip
 
             # Remap: check which SelectParties slot and replace with free_slots[]
@@ -707,6 +711,7 @@ class RemapPartiesToFreeSlots(_Instruction):
             asm.LDA(0xea, asm.DIR),               # free_slots[2]
 
             "STORE_REMAP",
+            asm.ORA(0xee, asm.DIR),               # merge with preserved non-party bits
             asm.STA(character_party_start, asm.ABS_X),  # write remapped party
 
             "CHAR_NEXT_NO_PLX",
@@ -862,9 +867,12 @@ class FinalizeBranchPartySelect(_Instruction):
 
             "REMAP_LOOP",
             asm.LDA(character_party_start, asm.ABS_X),
+            asm.AND(0x07, asm.IMM8),                         # isolate party bits
             asm.CMP(0x01, asm.IMM8),                         # assigned to slot 1 by SelectParties?
             asm.BNE("REMAP_NEXT"),
-            asm.LDA(0xe7, asm.DIR),                          # load saved party mask
+            asm.LDA(character_party_start, asm.ABS_X),       # reload full byte
+            asm.AND(0xf8, asm.IMM8),                         # clear party bits, keep flags
+            asm.ORA(0xe7, asm.DIR),                          # merge saved party index
             asm.STA(character_party_start, asm.ABS_X),       # remap to original slot
 
             "REMAP_NEXT",


### PR DESCRIPTION
Root cause for 1-party and 2-party formation breaking (can move but can't interact): RemapPartiesToFreeSlots compared the full $1850 byte against bare party numbers (0x01, 0x02). Since $1850 includes the enabled flag (0x40), a character in party 1 has byte 0x41, which fails CMP #$01 and CMP #$02, falling through to "must be party 3". Every enabled character got corrupted to party 3 with the enabled bit cleared.

Fix in RemapPartiesToFreeSlots:
- Save non-party bits ($1850 AND #$F8) to $ee scratch before comparing
- Isolate party bits (AND #$07) for the CMP chain
- At STORE_REMAP, ORA the new party value with saved non-party bits

Same fix in FinalizeBranchPartySelect's REMAP_LOOP:
- Isolate party bits before CMP #$01
- Reload and mask the full byte, ORA with saved party index

Also add missing field.FreeMovement() to 1-party path in narshe_wob.py. Without it, the event system never releases the input lock after the NPC event script returns.

https://claude.ai/code/session_014JQi31dhQX5g44KMWr5NYd