### PR TITLE
Add debug route destination support for ruination mode

### DIFF
--- a/args/doors.py
+++ b/args/doors.py
@@ -69,8 +69,8 @@ def parse(parser):
                        help="Randomize overworld entrances across worlds")
 
     # Debug options
-    doors.add_argument("-debug_dest", "--debug-route-destination", type=str, default=None,
-                       help="Output the shortest route from world map to specified room (use with -drdc)")
+    doors.add_argument("-debug_dest", "--debug-route-destination", nargs='+', type=str, default=None,
+                       help="Output the shortest route to specified room(s). Supports multiple rooms. (use with -drdc or -ruin)")
 
 def process(args):
     #pass
@@ -136,6 +136,9 @@ def flags(args):
         if args.ruination_mode == "custom":
             flags += " custom"
 
+        if args.debug_route_destination:
+            flags += " -debug_dest " + " ".join(args.debug_route_destination)
+
     elif args.door_randomize_all:
         # -dra supercedes all but -ruin
         flags += " -dra"
@@ -149,7 +152,7 @@ def flags(args):
         flags += " -drdc"
 
         if args.debug_route_destination:
-            flags += " -debug_dest " + str(args.debug_route_destination)
+            flags += " -debug_dest " + " ".join(args.debug_route_destination)
 
     elif args.door_randomize_each:
         # -dre supercedes all but -dra, -drdc

--- a/data/doors.py
+++ b/data/doors.py
@@ -816,7 +816,8 @@ class Doors():
 
         # Debug: print shortest route if requested (after all postprocessing)
         if self.args.debug_route_destination:
-            self.debug_print_shortest_route(map, self.args.debug_route_destination)
+            for dest in self.args.debug_route_destination:
+                self.debug_print_shortest_route(map, dest)
 
         # Return map
         self.map = map

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -4148,6 +4148,10 @@ class ruination_map():
         for i in range(3):
             map[1].append([traps_to_kt[i], pits_into_kt[i]])
 
+        # Debug: print shortest route if requested (after all finalization)
+        if self.args.debug_route_destination:
+            self.debug_print_shortest_route(self.args.debug_route_destination)
+
         return map
 
     def _choose_reward_with_exclusion(self, possible_types, characters, espers, items, exclude_chars):
@@ -4272,6 +4276,177 @@ class ruination_map():
                                 self.RewardsAvailable[1] -= 1
                         # Then process them all
                         self.process_rewards(unlocked_rewards, characters, espers, items, v[0], exclude_chars)
+
+    def debug_print_shortest_route(self, destination_rooms):
+        """Find and print the shortest route from hub to each destination room in ruination mode.
+
+        Supports room IDs (int or string) and area names from RUIN_ROOM_SETS.
+        For each destination, identifies which branch it's on and prints the
+        shortest path from that branch's hub.
+
+        Args:
+            destination_rooms: List of target room IDs or area names (strings from argparse)
+        """
+        import networkx as nx
+        from data.map_exit_extra import exit_data
+        from data.event_exit_info import event_exit_info
+
+        def get_door_name(door_id):
+            """Get human-readable name for a door/exit ID."""
+            if door_id in exit_data:
+                return exit_data[door_id][1]
+            elif door_id in event_exit_info:
+                return event_exit_info[door_id][4]
+            else:
+                return f"Door {door_id}"
+
+        def find_room_on_branches(room_id):
+            """Find which branch contains a room, handling compound IDs from merging."""
+            for branch_id, branch in enumerate(self.branches):
+                for node_id in branch.net.nodes:
+                    if node_id == room_id:
+                        return branch_id, branch, node_id
+                    # Check compound IDs (e.g., 'ruin_hub_0+421+422')
+                    if isinstance(node_id, str):
+                        parts = str(node_id).split('+')
+                        if str(room_id) in parts:
+                            return branch_id, branch, node_id
+            return None, None, None
+
+        def find_hub(branch):
+            """Find the hub node ID for a branch."""
+            for node_id in branch.net.nodes:
+                if 'ruin_hub_' in str(node_id):
+                    return node_id
+            return None
+
+        def find_connecting_info(branch, room1, room2):
+            """Find the exit IDs connecting two rooms in the branch map."""
+            # Check door pairs (two-way)
+            for d1, d2 in branch.map[0]:
+                r1 = branch.rooms.get_room_from_element(d1)
+                r2 = branch.rooms.get_room_from_element(d2)
+                if not r1 or not r2:
+                    continue
+                if r1.id == room1 and r2.id == room2:
+                    has_reverse = branch.net.has_edge(room2, room1)
+                    arrow = "<-->" if has_reverse else "-->"
+                    return f"{d1} ({get_door_name(d1)}) {arrow} {d2} ({get_door_name(d2)})"
+                if r1.id == room2 and r2.id == room1:
+                    has_reverse = branch.net.has_edge(room2, room1)
+                    arrow = "<-->" if has_reverse else "-->"
+                    return f"{d2} ({get_door_name(d2)}) {arrow} {d1} ({get_door_name(d1)})"
+
+            # Check trap pairs (one-way)
+            for d1, d2 in branch.map[1]:
+                r1 = branch.rooms.get_room_from_element(d1)
+                r2 = branch.rooms.get_room_from_element(d2)
+                if not r1 or not r2:
+                    continue
+                if r1.id == room1 and r2.id == room2:
+                    return f"TRAP {d1} ({get_door_name(d1)}) --> PIT {d2} ({get_door_name(d2)})"
+
+            return "(connection not found in map)"
+
+        def print_route(destination_label, branch_id, branch, hub_id, target_node):
+            """Print the route from hub to target node."""
+            if target_node == hub_id:
+                print(f"\n{'='*80}")
+                print(f"DEBUG ROUTE: '{destination_label}' is in the hub compound on Branch {branch_id}")
+                print(f"  Hub: {hub_id}")
+                print(f"{'='*80}\n")
+                return
+
+            try:
+                path = nx.shortest_path(branch.net, source=hub_id, target=target_node)
+            except nx.NetworkXNoPath:
+                print(f"\n{'='*80}")
+                print(f"DEBUG ROUTE: No path from hub to '{destination_label}' on Branch {branch_id}")
+                print(f"  Hub: {hub_id}")
+                print(f"  Target node: {target_node}")
+                print(f"{'='*80}\n")
+                return
+
+            print(f"\n{'='*80}")
+            print(f"DEBUG ROUTE: Hub --> '{destination_label}' (Branch {branch_id})")
+            print(f"{'='*80}")
+            print(f"  Path length: {len(path)} rooms\n")
+
+            for i in range(len(path) - 1):
+                current_room = path[i]
+                next_room = path[i + 1]
+                connection = find_connecting_info(branch, current_room, next_room)
+                print(f"  {current_room}: {connection}")
+
+            print(f"  {path[-1]}: (destination)")
+            print(f"{'='*80}\n")
+
+        # Process each destination
+        for dest_str in destination_rooms:
+            # Try to convert to int (room IDs can be integers)
+            try:
+                dest = int(dest_str)
+            except (ValueError, TypeError):
+                dest = dest_str
+
+            # Check if it's an area name in RUIN_ROOM_SETS
+            if dest in RUIN_ROOM_SETS:
+                area_name = dest
+                if area_name in self.AreasUsed:
+                    branch_id = self.AreasUsed[area_name]
+                    branch = self.branches[branch_id]
+                    hub_id = find_hub(branch)
+
+                    if hub_id is None:
+                        print(f"DEBUG ERROR: Hub not found on branch {branch_id}")
+                        continue
+
+                    # Find the closest room of this area from the hub
+                    area_rooms = RUIN_ROOM_SETS[area_name]
+                    best_path_len = float('inf')
+                    best_room_id = None
+                    best_target_node = None
+
+                    for room_id in area_rooms:
+                        _, _, target_node = find_room_on_branches(room_id)
+                        if target_node is not None and target_node != hub_id:
+                            try:
+                                path = nx.shortest_path(branch.net, source=hub_id, target=target_node)
+                                if len(path) < best_path_len:
+                                    best_path_len = len(path)
+                                    best_room_id = room_id
+                                    best_target_node = target_node
+                            except nx.NetworkXNoPath:
+                                continue
+
+                    if best_target_node is not None:
+                        print_route(f"{area_name} (room {best_room_id})", branch_id, branch, hub_id, best_target_node)
+                    elif any(find_room_on_branches(r)[2] == hub_id for r in area_rooms):
+                        # Area rooms are merged into hub
+                        print(f"\n{'='*80}")
+                        print(f"DEBUG ROUTE: Area '{area_name}' is in the hub compound on Branch {branch_id}")
+                        print(f"  Hub: {hub_id}")
+                        print(f"{'='*80}\n")
+                    else:
+                        print(f"DEBUG ERROR: No reachable rooms from area '{area_name}' found on branch {branch_id}")
+                else:
+                    print(f"DEBUG ERROR: Area '{area_name}' was not placed on any branch.")
+                    print(f"  Areas used: {dict(sorted(self.AreasUsed.items(), key=lambda x: x[1]))}")
+                continue
+
+            # It's a room ID - find it on branches
+            branch_id, branch, target_node = find_room_on_branches(dest)
+            if branch is None:
+                print(f"DEBUG ERROR: Room '{dest}' not found on any branch.")
+                print(f"  Hint: use area names like {list(RUIN_ROOM_SETS.keys())[:5]}... or room IDs from RUIN_ROOM_SETS")
+                continue
+
+            hub_id = find_hub(branch)
+            if hub_id is None:
+                print(f"DEBUG ERROR: Hub not found on branch {branch_id}")
+                continue
+
+            print_route(str(dest), branch_id, branch, hub_id, target_node)
 
 
 def ruination_start_game_mod(dialogs, party):


### PR DESCRIPTION
Implements --debug-route-destination flag for ruination mode, replicating the existing dungeon crawl functionality. For each requested room, finds which branch it's on and prints the shortest path from that branch's hub.

Changes:
- Flag now accepts multiple rooms (nargs='+') for both -drdc and -ruin
- Supports both room IDs (int/string) and area names from RUIN_ROOM_SETS
- Shows door/trap connection details for each step in the path
- Handles compound room IDs from loop compression/merging

Usage: python3 wc.py -i ffiii.smc -ruin -debug_dest Doma 421 ZoneEater

https://claude.ai/code/session_01Cz1QdoUYUZ94jDFu7H14U8