### PR TITLE
Fix Mobliz WoR party formation for ruination mode

### DIFF
--- a/event/mobliz_wor.py
+++ b/event/mobliz_wor.py
@@ -77,7 +77,10 @@ class MoblizWOR(Event):
             field.Branch(space.end_address + 1), # skip nops
         )
 
-        space = Reserve(0xc4c09, 0xc4c1a, "mobliz wor jump straight to attacking phunbaba", field.NOP())
+        # In ruination mode, this space is reserved by character_mod/esper_item_mod
+        # to inject SetupBranchPartySelect before the Phunbaba 3 battle
+        if not self.args.ruination_mode:
+            space = Reserve(0xc4c09, 0xc4c1a, "mobliz wor jump straight to attacking phunbaba", field.NOP())
         space = Reserve(0xc4c88, 0xc4c8b, "mobliz wor phunbaba 2 TERRA!!", field.NOP())
         space = Reserve(0xc4c97, 0xc4cc7, "mobliz wor turn terra into esper", field.NOP())
         space.write(
@@ -131,6 +134,15 @@ class MoblizWOR(Event):
         space = Write(Bank.CC, src, "character joins before Mobliz battle")
         add_character = space.start_address
 
+        # In ruination mode, inject SetupBranchPartySelect before Phunbaba 3 battle
+        # to capture the full party before bababreath can blow members away.
+        # After Setup, everyone is moved to P1, so AddCharacterToParty(char, 1) is correct.
+        if self.args.ruination_mode:
+            space = Reserve(0xc4c09, 0xc4c1a, "mobliz wor setup branch party select before phunbaba 3", field.NOP())
+            space.write(
+                field.SetupBranchPartySelect(character),
+            )
+
         space = Reserve(0xc4cca, 0xc4cd9, "mobliz wor add character to party before phunbaba 4 if room available", field.NOP())
         space.write(
             field.Call(add_character),
@@ -140,11 +152,22 @@ class MoblizWOR(Event):
 
         space = Reserve(0xc4cda, 0xc4cef, "mobliz wor phunbaba 4 battle, esper terra and children scene", field.NOP())
         space.add_label("FINISH_EVENT", 0xc502a),
-        space.write(
-            field.InvokeBattle(boss_pack_id),
-            field.RecruitAndSelectParty(character),
-            field.Branch("FINISH_EVENT"), # skip scene
-        )
+        if self.args.ruination_mode:
+            # Decompose RecruitAndSelectParty: skip SetupBranchPartySelect (already called
+            # before Phunbaba 3) and just do recruit + party select + finalize
+            space.write(
+                field.InvokeBattle(boss_pack_id),
+                field.RecruitCharacter(character),
+                field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),
+                field.FinalizeBranchPartySelect(),
+                field.Branch("FINISH_EVENT"),
+            )
+        else:
+            space.write(
+                field.InvokeBattle(boss_pack_id),
+                field.RecruitAndSelectParty(character),
+                field.Branch("FINISH_EVENT"), # skip scene
+            )
 
         space = Reserve(0xc503f, 0xc5059, "mobliz wor add terra to party", field.NOP())
         space.write(
@@ -169,6 +192,17 @@ class MoblizWOR(Event):
 
         boss_pack_id = self.get_boss("Phunbaba 4")
 
+        # In ruination mode, inject SetupBranchPartySelect before Phunbaba 3 battle
+        # and wrap party select with FinalizeBranchPartySelect.
+        # 0xFF sentinel = no new recruit character.
+        if self.args.ruination_mode:
+            space = Reserve(0xc4c09, 0xc4c1a, "mobliz wor setup branch party select before phunbaba 3", field.NOP())
+            if not self.args.shuffle_random_phunbaba3:
+                # Party select will happen → need Setup/Finalize pair
+                space.write(
+                    field.SetupBranchPartySelect(0xFF),
+                )
+
         space = Reserve(0xc4cca, 0xc4cec, "mobliz wor phunbaba 4 battle, esper terra and children scene", field.NOP())
         space.add_label("FINISH_EVENT", 0xc502a),
         space.write(
@@ -178,6 +212,10 @@ class MoblizWOR(Event):
             space.write(
                 field.Call(field.REFRESH_CHARACTERS_AND_SELECT_PARTY),
             )
+            if self.args.ruination_mode:
+                space.write(
+                    field.FinalizeBranchPartySelect(),
+                )
         space.write(
             field.FadeOutSong(0),
             field.Branch("FINISH_EVENT"), # skip scene

--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -749,7 +749,7 @@ class SetupBranchPartySelect(_Instruction):
     """Prepares the party select screen for branch recruitment in ruination mode.
 
     When the active party is on a branch (has its AWAY bit set):
-    - Saves the current party index to scratchpad $14 for FinalizeBranchPartySelect
+    - Saves the current party index to persistent event RAM for FinalizeBranchPartySelect
     - Moves current party members to party 1 (so SelectParties assigns them correctly)
     - Parks Party 1 members at party index 4 (a sentinel value unused by the game)
       to hide them from SelectParties' post-menu routines ($714A/$6F67) which
@@ -781,9 +781,10 @@ class SetupBranchPartySelect(_Instruction):
             asm.AND(party_away_byte, asm.ABS),               # test if party is away
             asm.BEQ("DONE"),                                 # not on branch → no-op
 
-            # Save party index to scratchpad for FinalizeBranchPartySelect
+            # Save party index to persistent event RAM for FinalizeBranchPartySelect
+            # Uses low byte of SCRATCH event word ($1FFA) which survives battle transitions
             asm.LDA(current_party, asm.ABS),
-            asm.STA(0x3f, asm.DIR),
+            asm.STA(event_word.address(event_word.SCRATCH), asm.ABS),
 
             # Zero character_available and CHARACTERS_AVAILABLE
             asm.STZ(char_available_addr, asm.ABS),           # chars 0-7 available = 0
@@ -877,12 +878,12 @@ class FinalizeBranchPartySelect(_Instruction):
     - Remaps characters parked at index 4 (by SetupBranchPartySelect) back to party 1
     - Recomputes character_available: available = recruited AND NOT in_away_party
     - Recomputes CHARACTERS_AVAILABLE count
-    - Clears $14
+    - Clears the persistent party index storage
 
-    When $14 is zero (not on branch or Setup wasn't called), this is a no-op.
+    Party index is stored in persistent event RAM (SCRATCH event word) by SetupBranchPartySelect,
+    so this opcode can be called across battle boundaries (not limited to immediate use).
 
-    Uses scratchpad RAM $10-$14 during execution.  NOTE: scratchpad MUST ONLY be used immediately, it will not persist
-    between function calls!
+    Uses scratchpad RAM $30-$33 during execution for away-party lookup table.
 
     No arguments."""
     def __init__(self):
@@ -907,8 +908,9 @@ class FinalizeBranchPartySelect(_Instruction):
             #asm.JMP(0x9b5c, asm.ABS),                            # next command
             #"NOT_DONE",
 
-            # Step 0: Reload current party from storage
-            asm.LDA(0x3f, asm.DIR),
+            # Step 0: Reload current party from persistent event RAM (set by SetupBranchPartySelect)
+            # Uses low byte of SCRATCH event word ($1FFA) which survives battle transitions
+            asm.LDA(event_word.address(event_word.SCRATCH), asm.ABS),
             asm.STA(current_party, asm.ABS),
 
             # Step 1: Remap characters from slot 1 → saved party slot
@@ -1100,8 +1102,8 @@ class FinalizeBranchPartySelect(_Instruction):
             asm.CPX(CHARACTER_COUNT, asm.IMM16),
             asm.BNE("AVAIL_LOOP"),
 
-            # Clear scratchpad $3f so future calls are no-ops
-            asm.STZ(0x3f, asm.ABS),
+            # Clear persistent event RAM so future calls start clean
+            asm.STZ(event_word.address(event_word.SCRATCH), asm.ABS),
 
             asm.LDA(0x01, asm.IMM8),                        # command size = 1 (opcode only)
             asm.JMP(0x9b5c, asm.ABS),


### PR DESCRIPTION
SetupBranchPartySelect must be called before Phunbaba 3 battle so the full party roster is captured before bababreath can blow members away.  This required making the Setup/Finalize pair work across battle boundaries by persisting the party index in event RAM (SCRATCH word at $1FFA) instead of volatile scratchpad $3F.

Changes:
- SetupBranchPartySelect: save party index to persistent event RAM
- FinalizeBranchPartySelect: read party index from persistent event RAM
- character_mod: inject Setup before Phunbaba 3, decompose RecruitAndSelectParty after Phunbaba 4 (skip redundant Setup)
- esper_item_mod: inject Setup before Phunbaba 3 when party select is needed, wrap party select with Finalize

https://claude.ai/code/session_01Azv3z3cTWALmHUEvRgAgZd