### PR TITLE
Disable entrance_door_patch for door 1558 in ruination mode

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -920,6 +920,10 @@ class Maps():
         #         # Delete the event tile
         #         self.delete_event(info[0], info[1], info[2])  # delete the original event
 
+        # In ruination mode, disable the entrance_door_patch for door 1558
+        if self.args.ruination_mode:
+            entrance_door_patch.pop(1558, None)
+
         # Bundle exit_door_patch and entrance_door_patch data for transitions
         for m in exit_door_patch.keys():
             if m in map.keys():


### PR DESCRIPTION
The Figaro Castle underground state patch for door 1558 is not needed in ruination mode. Remove it from the entrance_door_patch dict before any downstream code references it.

https://claude.ai/code/session_018d4GLd8iujaqLFfYYwW4rU