### PR TITLE
Fix unexpected event bits set on Figaro Castle WoR entrance in ruinat…

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -924,6 +924,13 @@ class Maps():
         if self.args.ruination_mode:
             entrance_door_patch.pop(1558, None)
 
+            # Disable require_event_bit for Figaro Castle entrance doors.
+            # Rooms 68 (WoB) and '68R' (WoR) propagate bits to doors 197/1156
+            # and 4197/5156 via room_require_event_bit. These are only needed
+            # for classic door randomization.
+            for door in [197, 1156, 4197, 5156]:
+                require_event_bit.pop(door, None)
+
         # Bundle exit_door_patch and entrance_door_patch data for transitions
         for m in exit_door_patch.keys():
             if m in map.keys():


### PR DESCRIPTION
…ion mode

room_require_event_bit propagates Figaro Castle bits (prison door, Lone Wolf, prisoners, GOT_FALCON) to all doors in rooms 68/'68R', including world map entrance doors 197/1156/4197/5156. This is only needed for classic door randomization. In ruination mode, pop these entries from require_event_bit to prevent unwanted bits from being written into exit events.

https://claude.ai/code/session_013B9p9ZGwSDXTqAMnkikt7e