### PR TITLE
Fix airship teleporting to player in ruination mode for event tile doors

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -798,7 +798,7 @@ class Maps():
                         print('Updated event exit info: ', e, hex(event_exit_info[e][0]))
 
             # Connect one-way event exits using the Transitions class
-            self.transitions = Transitions(self.doors.map[1], self.rom, self.exits.exit_original_data, event_exit_info)
+            self.transitions = Transitions(self.doors.map[1], self.rom, self.exits.exit_original_data, event_exit_info, args=self.args)
             self.transitions.write(maps=self)
 
             # Connect two-way doors
@@ -1007,7 +1007,7 @@ class Maps():
                 print('Connecting: ' + str(m) + ' to ' + str(map[m]))
             transition_map.append([m, map[m]])
         dt = Transitions(transition_map, self.rom, self.exits.exit_original_data, event_exit_info,
-                         self.exit_event_data_to_include)  # self.exit_event_addr_to_call
+                         self.exit_event_data_to_include, args=self.args)  # self.exit_event_addr_to_call
         dt.write(maps=self)
 
         # Connect logical WOR exits: 4000 <= m,  m_WOB = (m - 4000).

--- a/data/transitions.py
+++ b/data/transitions.py
@@ -27,9 +27,10 @@ class Transitions:
     FREE_MEMORY = False
     verbose = False
 
-    def __init__(self, mapping, rom, exit_data, event_data, include_script_data=None):
+    def __init__(self, mapping, rom, exit_data, event_data, include_script_data=None, args=None):
         self.transitions = []
         self.rom = rom
+        self.args = args
         self.include_script_data = include_script_data
         if self.include_script_data is None:
             self.include_script_data = {}
@@ -231,7 +232,10 @@ class Transitions:
             # Add patched lines after map transition
             src_end = src_end[:5] + en_patch + src_end[5:]
 
-            if t.entr.dest_location[0] in [0x0, 0x1]:
+            summon_airship = t.entr.dest_location[0] in [0x0, 0x1]
+            if self.args is not None and self.args.ruination_mode:
+                summon_airship = False
+            if summon_airship:
                 # This is loading to a world map.  Summon the airship, and make everything happen before that.
                 get_airship_src = SummonAirship(t.entr.dest_location[0], t.entr.dest_location[1], t.entr.dest_location[2], bytes=True)
                 #print([hex(a)[2:] for a in get_airship_src])


### PR DESCRIPTION
The Transitions class (which handles event tiles acting as doors) was unconditionally calling SummonAirship when connecting to a world map. The create_exit_event and shared_map_exit_event methods already had ruination mode checks to skip this, but Transitions did not.

Pass args to the Transitions class and skip airship summoning in ruination mode, matching the behavior of the other connection paths.

https://claude.ai/code/session_01VJvFCq2XFzKcmQv1MUKiTf