### PR TITLE
Fix wrong music when trap 2054 connects to pit 3075 in ruination mode

### DIFF
--- a/event/veldt_cave_wor.py
+++ b/event/veldt_cave_wor.py
@@ -135,18 +135,27 @@ class VeldtCaveWOR(Event):
             # transition so the airship is moved.
             from event.switchyard import AddSwitchyardEvent, GoToSwitchyard
             event_id = 2075
-            switchyard_src = [
-                field.FadeInSong(0x08, 0x30),
-                field.LoadMap(self.airship_thamasa[0], direction.DOWN, default_music=False, x=self.airship_thamasa[1],
-                              y=self.airship_thamasa[2], fade_in=False, airship=True),
-                vehicle.SetPosition(self.airship_thamasa[1], self.airship_thamasa[2]),
-                vehicle.ClearEventBit(event_bit.TEMP_SONG_OVERRIDE),
-                vehicle.LoadMap(0x15d, direction.DOWN, default_music=True, x=61, y=13, update_parent_map=True),
-                # Always show interceptor in door rando
-                #field.ClearEventBit(npc_bit.INTERCEPTOR_STRAGO_ROOM),
-                field.FadeInScreen(),
-                field.Return(),
-            ]
+            if self.args.ruination_mode:
+                # In ruination mode, there is no airship. Skip the world map intermediate step
+                # and load Thamasa directly with default music.
+                switchyard_src = [
+                    field.ClearEventBit(event_bit.TEMP_SONG_OVERRIDE),
+                    field.LoadMap(0x15d, direction.DOWN, default_music=True, x=61, y=13, fade_in=True),
+                    field.Return(),
+                ]
+            else:
+                switchyard_src = [
+                    field.FadeInSong(0x08, 0x30),
+                    field.LoadMap(self.airship_thamasa[0], direction.DOWN, default_music=False, x=self.airship_thamasa[1],
+                                  y=self.airship_thamasa[2], fade_in=False, airship=True),
+                    vehicle.SetPosition(self.airship_thamasa[1], self.airship_thamasa[2]),
+                    vehicle.ClearEventBit(event_bit.TEMP_SONG_OVERRIDE),
+                    vehicle.LoadMap(0x15d, direction.DOWN, default_music=True, x=61, y=13, update_parent_map=True),
+                    # Always show interceptor in door rando
+                    #field.ClearEventBit(npc_bit.INTERCEPTOR_STRAGO_ROOM),
+                    field.FadeInScreen(),
+                    field.Return(),
+                ]
             AddSwitchyardEvent(event_id=event_id, maps=self.maps, src=switchyard_src)
 
             space.write([


### PR DESCRIPTION
The switchyard event for exit 2075 (Veldt Cave boss → Thamasa) was always going through a world map intermediate step with airship summoning and FadeInSong(0x08) ("Searching for Friends"). In ruination mode there is no airship, so the switchyard now loads Thamasa directly with default_music=True, which plays the correct Thamasa theme.

https://claude.ai/code/session_01HnyiSBwvWt48nyERA7tmXS