### PR TITLE
Disable Y-party switching in Fanatics Tower for ruination mode

### DIFF
--- a/event/fanatics_tower.py
+++ b/event/fanatics_tower.py
@@ -30,6 +30,9 @@ class FanaticsTower(Event):
         self.finish_magimaster_check_mod()
         self.finish_strago_check_mod()
 
+        if self.args.ruination_mode:
+            self.ruination_mod()
+
         self.log_reward(self.reward1)
         self.log_reward(self.reward2)
 
@@ -210,3 +213,34 @@ class FanaticsTower(Event):
         space.write(
             field.Call(finish_check),
         )
+
+    def ruination_mod(self):
+        from data.map_event import MapEvent
+
+        # Disable Y-party switching when entering Fanatics Tower exterior (before going inside)
+        src = [
+            field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            field.Return(),
+        ]
+        space = Write(Bank.CB, src, "fanatics tower disable y-party switching")
+        disable_y_switch_event = space.start_address
+
+        new_event = MapEvent()
+        new_event.x = 8
+        new_event.y = 1
+        new_event.event_address = disable_y_switch_event - EVENT_CODE_START
+        self.maps.add_event(0x16a, new_event)
+
+        # Re-enable Y-party switching when heading toward exit inside tower
+        src = [
+            field.SetEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            field.Return(),
+        ]
+        space = Write(Bank.CB, src, "fanatics tower enable y-party switching")
+        enable_y_switch_event = space.start_address
+
+        new_event = MapEvent()
+        new_event.x = 7
+        new_event.y = 29
+        new_event.event_address = enable_y_switch_event - EVENT_CODE_START
+        self.maps.add_event(0x16b, new_event)


### PR DESCRIPTION
Adds event tiles to prevent Y-button party switching while in FT, since the magic-only battle restriction would not apply to a swapped-in party. Tile on map 0x16a (8,1) clears the bit on entry, tile on map 0x16b (7,29) restores it on exit.

https://claude.ai/code/session_015M5PwbC1s7qG6eDzyWZghT