### PR TITLE
Fix ruination party teleport after Moogle Defense battle

### DIFF
--- a/event/narshe_moogle_defense.py
+++ b/event/narshe_moogle_defense.py
@@ -434,6 +434,17 @@ class NarsheMoogleDefense(Event):
             space = Reserve(0xcaa99, 0xcaa9c, "Moogle defense handle Y-party switch", field.NOP())
             space.write(field.Call(self.handle_y_party_switch_addr))
 
+            # Reserve the vanilla post-battle gap between InvokeBattle and victory code.
+            # The vanilla code here switches active_party to 1 for the victory scene,
+            # which corrupts other parties' map data in ruination mode where the
+            # active party can be 1, 2, or 3.
+            space = Reserve(0xcadaf, 0xcade4, "moogle defense post-battle (ruination)", field.NOP())
+            space.write(
+                field.BranchIfBattleEventBitClear(battle_bit.PARTY_ANNIHILATED, space.end_address + 1),
+                field.Dialog(1744),
+                field.Call(field.GAME_OVER),
+            )
+
         else:
             self.add_moogles_to_parties()
 


### PR DESCRIPTION
The vanilla post-battle code (0xCADAF-0xCADE4) between InvokeBattle and the victory handler contains a SetParty(1) that forces the active party to party 1 for the vanilla victory scene. In ruination mode, the active party can be 1, 2, or 3, so this rogue SetParty(1) corrupts the active party state. When the subsequent LoadMap runs with the wrong active party, it overwrites the wrong party's save RAM map data, causing other parties to appear on incorrect maps when switching via Y.

Fix: Reserve the vanilla post-battle gap in ruination mode and replace it with a clean battle-result check (game over on loss, fall through to victory on win) that preserves the original active party.

https://claude.ai/code/session_01Fq9UiYnqupt5By79uG8F7H