### PR TITLE
Fix ruin-lonewolf room missing from Narshe area definition

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -266,7 +266,7 @@ RUIN_ROOM_SETS = {
     'DarylsTomb': [377, 378, 379, 380, 381, 382, 383, 384, 386, 'ruin-daryl', 388, 389, 390, 391, 392, 393],
     'ZoneEater': [356, 357, 358, '358b', 359, '359b', 361, 362, 363],
     'MtKolts': [145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160],
-    'Narshe': ['ruin-narshe', 36, '37a', 38, 40, '41a', 42, 43, 44, 45, 'ruin-whelk', 47, 65, 49, 50, 51, 61],   # Narshe WOR + northern caves (swap out WOB Whelk 46 --> 59) + snow battlefield + Tritoch + Umaro exit + moogle mines (swap out 48 --> 65 for moogle defense)
+    'Narshe': ['ruin-narshe', 36, '37a', 38, 40, '41a', 'ruin-lonewolf', 42, 43, 44, 45, 'ruin-whelk', 47, 65, 49, 50, 51, 61],   # Narshe WOR + northern caves (swap out WOB Whelk 46 --> 59) + snow battlefield + Tritoch + Umaro exit + moogle mines (swap out 48 --> 65 for moogle defense) + Lone Wolf reward room
     'Zozo': ['ruin-zozo', '294r', '295r', '296r', '301r', '305r', '306r', '307r', '308r', '309r'],
     'ZozoTower': [297, 298, 299, 300, 302, '303a', '303b', 304, 310, 311, 312, 313],
     'MtZozo': [250, 251, 252, 253, 254, 255, 256],


### PR DESCRIPTION
The ruin-lonewolf room (containing pit 3180) was defined in room_data and as a reward room, but never added to the RUIN_ROOM_SETS Narshe area list. This caused ForceConnections to fail with AttributeError when trying to connect trap 2180 -> pit 3180, because get_room_from_element(3180) returned None.

https://claude.ai/code/session_01GKbMkzrNWiTDBaqtWy1xQV