### PR TITLE
Fix spoiler log missing characters assigned after map generation

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -4499,6 +4499,28 @@ class ruination_map():
                 return "Item"
             return "?"
 
+        # Capture rewards assigned after map generation (e.g., by safety code in events.py)
+        # ROOM_REWARD entries are shared Reward objects updated by both ruination map gen
+        # and the post-ruination reward distribution in events.py
+        logged_names = {e['name'] for e in self.reward_log}
+        for room_id, rewards in ROOM_REWARD.items():
+            for reward_name, slot in rewards.items():
+                if reward_name not in logged_names and slot.id is not None and slot.type is not None:
+                    # Determine which branch this room is on (if any)
+                    branch_id = -1
+                    for bid, walks in rebuilt.items():
+                        if room_id in walks.net.nodes:
+                            branch_id = bid
+                            break
+                    self.reward_log.append({
+                        'order': len(self.reward_log) + 1,
+                        'name': reward_name,
+                        'branch': branch_id,
+                        'type': slot.type,
+                        'reward_id': slot.id,
+                        'reward_room': room_id,
+                    })
+
         # Build the log output
         log_lines = []
 


### PR DESCRIPTION
The ruination spoiler log only captured rewards assigned during generate_map_with_characters() via process_rewards(). Characters assigned by the post-ruination safety code in events.py (lines 275-281) were not included, causing obtainable characters like SABIN and LOCKE to be missing from the Character Rewards section.

Now scans ROOM_REWARD for any assigned rewards not already in reward_log before building the spoiler output, since generate_spoiler_log runs after all reward assignments are finalized.

https://claude.ai/code/session_011PKj14G89yRQTq1WpM3WVH