### PR TITLE
Change ruination warp behavior: disable only on Kefka's Tower maps

### DIFF
--- a/data/maps.py
+++ b/data/maps.py
@@ -494,10 +494,22 @@ class Maps():
         if self.args.no_saves == 'full':
             self._disable_saves()
 
-        # Make no maps warpable for -ruination-mode: all warping handled with warp points
+        # Ruination mode: disable warping on Kefka's Tower maps (warp stones go to Esper World)
+        # Warping remains disabled on vanilla no-warp maps (Phoenix Cave, Fanatics Tower)
+        # Ancient Castle maps are made warpable (they are no-warp in vanilla)
         if self.args.ruination_mode:
-            for map_index, cur_map in enumerate(self.maps):
-                self.properties[map_index].warpable = 0
+            kefkas_tower_maps = [
+                0x11F, 0x123, 0x124, 0x125, 0x126, 0x127, 0x128, 0x12F, 0x130,  # KT interior
+                0x149, 0x14B, 0x14D, 0x14E, 0x14F,                                # KT mid
+                0x150, 0x151, 0x152, 0x153,                                        # KT upper
+                0x160, 0x162, 0x163, 0x164, 0x165,                                 # KT rooms
+                0x199, 0x19A, 0x19B, 0x19C,                                        # KT factory/final
+            ]
+            ancient_castle_maps = [0x191, 0x192, 0x196, 0x197, 0x198]
+            for map_id in kefkas_tower_maps:
+                self.properties[map_id].warpable = 0
+            for map_id in ancient_castle_maps:
+                self.properties[map_id].warpable = 1
             self._disable_map_name_popups()
 
         # Make all maps warpable for -door-randomize-dungeon-crawl


### PR DESCRIPTION
Instead of disabling warping on all maps (which prevented warp stones/spell from working), only disable warping on Kefka's Tower maps. This allows warp to send players back to Esper World on all other maps. Ancient Castle maps (0x191-0x198) are explicitly made warpable since they are no-warp in vanilla. Phoenix Cave and Fanatics Tower remain non-warpable per vanilla.

https://claude.ai/code/session_01RRiFkzA1M2ceWCf8Gb1uWY