### PR TITLE
Fix warp stone priority: ruination mode should take precedence over d…

### DIFF
--- a/event/start.py
+++ b/event/start.py
@@ -110,7 +110,21 @@ class Start(Event):
             ]
             self.warps.add_code(src_safety)
             
-        if self.args.debug or self.args.door_randomize_dungeon_crawl:
+        if self.args.ruination_mode:
+            # Ruination mode: warps should send you to the starting position in the Esper World
+            # Warps should also NOT clear or set any bits!  Just the map transition.
+            # Note that warping out of Kefka's Tower should then be prohibited, except via warp points.
+            warp_to_esper_world_src = [
+                field.LoadMap(0xda, direction.DOWN, default_music=True,
+                              x=55, y=33, fade_in=True, airship=False),
+                field.ClearEventBit(event_bit.IN_WOR),  # we're going back to WoB
+                field.Return(),  # return
+            ]
+            self.warps.add_warp_override(warp_to_esper_world_src)
+
+            # Note that custom warps will be disallowed (Phoenix Cave, Kefka's Tower)
+
+        elif self.args.debug or self.args.door_randomize_dungeon_crawl:
             # Dungeon Crawl mode doesn't have a well-defined parent map.
             # Warp stones will always go to the airship over WOB Narshe.
             warp_to_narshe_src = [
@@ -128,21 +142,6 @@ class Start(Event):
             from data.warps import CUSTOM_WARP_BITS
             for bit in CUSTOM_WARP_BITS:
                 self.warps.add_bit(bit, 'clear')
-
-        elif self.args.ruination_mode:
-            # Ruination mode: warps should send you to the starting position in the Esper World
-            # Warps should also NOT clear or set any bits!  Just the map transition.
-            # Note that warping out of Kefka's Tower should then be prohibited, except via warp points.
-            warp_to_esper_world_src = [
-                field.LoadMap(0xda, direction.DOWN, default_music=True,
-                              x=55, y=33, fade_in=True, airship=False),
-                field.ClearEventBit(event_bit.IN_WOR),  # we're going back to WoB
-                field.Return(),  # return
-            ]
-            self.warps.add_warp_override(warp_to_esper_world_src)
-
-            # Note that custom warps will be disallowed (Phoenix Cave, Kefka's Tower)
-
 
         elif self.args.map_shuffle:
             # In Map Shuffle, parent map is well-defined, but sometimes the parent world is different.


### PR DESCRIPTION
…ebug

When both -ruin and -debug flags are used, the debug warp override (warp to airship over Narshe) was checked first, preventing the ruination warp (warp to Esper World) from being applied. Reorder the if/elif chain so ruination_mode is checked before debug.

https://claude.ai/code/session_01UxZ9j4q1SuzfRD21fwasJ8