### PR TITLE
Fix PARTY_1_AWAY event bit being wrongly cleared during party interac…

### DIFF
--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -838,6 +838,11 @@ class SetupBranchRecruit(_Instruction):
             asm.AND(0xf8, asm.IMM8),
             asm.ORA(0x04, asm.IMM8),  # P1 → P4
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM so $7077 bulk copy won't un-park
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.ORA(0x04, asm.IMM8),
+            asm.STA(save_ram_party_start, asm.ABS_X),
             asm.BRA("NEXT"),
 
             "CHECK_P2",
@@ -847,6 +852,11 @@ class SetupBranchRecruit(_Instruction):
             asm.AND(0xf8, asm.IMM8),
             asm.ORA(0x05, asm.IMM8),  # P2 → P5
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM so $7077 bulk copy won't un-park
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.ORA(0x05, asm.IMM8),
+            asm.STA(save_ram_party_start, asm.ABS_X),
             asm.BRA("NEXT"),
 
             "CHECK_P3",
@@ -856,6 +866,11 @@ class SetupBranchRecruit(_Instruction):
             asm.AND(0xf8, asm.IMM8),
             asm.ORA(0x06, asm.IMM8),  # P3 → P6
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM so $7077 bulk copy won't un-park
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.ORA(0x06, asm.IMM8),
+            asm.STA(save_ram_party_start, asm.ABS_X),
             asm.BRA("NEXT"),
 
             "SET_AVAIL_PARTY",
@@ -864,6 +879,11 @@ class SetupBranchRecruit(_Instruction):
             asm.AND(0xf8, asm.IMM8),  # keep non-party bits
             asm.ORA(0x01, asm.IMM8),  # set to Party 1
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.ORA(0x01, asm.IMM8),
+            asm.STA(save_ram_party_start, asm.ABS_X),
 
             # Set character_available bit
             asm.PHY(),
@@ -928,6 +948,10 @@ class SetupBranchRecruit(_Instruction):
             asm.LDA(character_party_start, asm.ABS_Y),
             asm.AND(0xf8, asm.IMM8),  # clear party bits (party 0)
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.STA(save_ram_party_start, asm.ABS_X),
 
             asm.RTS(),
         ]
@@ -977,6 +1001,11 @@ class SetupBranchRecruit(_Instruction):
             asm.AND(0xf8, asm.IMM8),  # keep non-party bits
             asm.ORA(0x11, asm.DIR),  # set to target party
             asm.STA(character_party_start, asm.ABS_Y),
+            # Mirror to save RAM
+            asm.LDA(save_ram_party_start, asm.ABS_X),
+            asm.AND(0xf8, asm.IMM8),
+            asm.ORA(0x11, asm.DIR),
+            asm.STA(save_ram_party_start, asm.ABS_X),
 
             # Set character_available bit
             asm.PHY(),


### PR DESCRIPTION
…tions

When party 1 was away and parties 2/3 interacted (swap or join), the PARTY_1_AWAY event bit was incorrectly cleared. Root cause: SetupBranchRecruit parked characters in field RAM only (party 1→4, 2→5, 3→6) but left save RAM unchanged. The vanilla $C0/7077 routine, called when SelectParties returns from the menu via $C6CA, bulk-copies save RAM party bytes back to field RAM for all 16 characters, destroying the parking. This caused FinalizeBranchRecruit to not find parked characters at slots 4/5/6, marking those parties as unused and clearing their AWAY bits.

The asymmetry (only P1 affected) occurred because SetupBranchRecruit sets current_party=1, and the vanilla post-menu routine $6F67 matches characters whose save RAM party equals current_party. P1's away characters had save_ram_party=1 matching current_party=1, while P2/P3 away characters had save_ram_party 2/3 which didn't match.

Fix: mirror all party byte changes to save RAM in SetupBranchRecruit's parking loop, active-party-to-P1 move, single-char recruit, and include-char-party helpers. This prevents $7077 from un-parking and $6F67 from false-matching.

https://claude.ai/code/session_012xov3MnKTPK1eFRmMPNgwD