### PR TITLE
Fix -no flag processor to handle multiple -no groups

### DIFF
--- a/args/ruin_preprocessor.py
+++ b/args/ruin_preprocessor.py
@@ -260,8 +260,9 @@ def preprocess_ruin_flag(argv=None):
         return argv
 
     # Collect flags to disable via -no and remove -no from argv FIRST
+    # Handle multiple -no groups: e.g. "-no flag1 -no flag2" or "-no flag1 flag2"
     flags_to_disable = set()
-    if '-no' in argv:
+    while '-no' in argv:
         no_index = argv.index('-no')
         argv.pop(no_index)  # Remove -no itself first
         # Collect and remove all following non-flag arguments


### PR DESCRIPTION
The preprocessor used `if` with `argv.index('-no')` which only ever processed the first `-no` group. Changed to `while` so that `-ruin -no flag1 -no flag2` correctly suppresses both flags.

https://claude.ai/code/session_01DUoyKed9g1AqaFhJj6E5df