### PR TITLE
Fix door 1564 placement: use safe landing position instead of event t…

### DIFF
--- a/event/daryl_tomb.py
+++ b/event/daryl_tomb.py
@@ -87,7 +87,7 @@ class DarylTomb(Event):
             # Create a door at Daryl's Tomb quick exit going to staircase.  Don't reset turtles.
             door_exit_id = 1563
             src = [
-                field.FadeLoadMap(0x12d, x=27, y=7, direction=direction.LEFT, fade_in=True, entrance_event=True, default_music=True),
+                field.FadeLoadMap(0x12d, x=25, y=9, direction=direction.LEFT, fade_in=True, entrance_event=True, default_music=True),
                 field.Return()
             ]
 


### PR DESCRIPTION
…ile position

In ruination mode, the staircase event at 0xa435d was loading map 0x12d at (27, 7), which is the exact position of event tile 1564. When Transitions creates a connection to 1564 using use_event_info=1563, it reads these coordinates from the modified ROM, placing the player directly on the event tile and causing an immediate return. Changed to (25, 9) to match event_door_connection_data[1563]'s safe landing position.

https://claude.ai/code/session_01PyYS93VeuuK8XNewZs7u7j