### PR TITLE
Add Doma WoB siege check to ruination mode

### DIFF
--- a/data/event_exit_info.py
+++ b/data/event_exit_info.py
@@ -549,6 +549,7 @@ entrance_door_patch = {
 
     # Doma siege entrance patch
     1240: [doma_siege_patch, True],
+    744: [lambda args: doma_siege_patch(args, exit_event_x=28, exit_event_y=33), True],  # Doma siege via inside door (ruination)
 
     # Figaro Castle WoR tentacles bit check patch (on entering SF Cave for map shuffle)
     262: [tentacles_bit_check(), False],

--- a/data/rooms.py
+++ b/data/rooms.py
@@ -152,6 +152,7 @@ room_data = {
     'dc-73': [[5213, 593], [], [], 1],          # Jidoor WOR + Owzers
     'dc-75': [[1261, 1260], [], [3075], 1],     # Thamasa WOR + Veldt Cave dest.
     'dc-76': [[5240], [2069], [3074], 1],       # Doma WOR
+    'ruin-doma': [[4418], [2069], [3074], 1],    # Doma WOR interior (ruination split: indoor stays WoR)
 
     # Ruination mode
     #'ruin_hub': [ [], [393, 394, 395], [3097, 3098, 3099], 1],  # Narshe school, 3 doors as oneways
@@ -1083,6 +1084,8 @@ forced_connections = {
 
     2180: [3180],   # Narshe Peak (41a) --> Lone Wolf reward room (ruin-lonewolf), logical only.
     2181: [3181],   # Lone Wolf reward room (ruin-lonewolf) --> Narshe Peak (41a), return.
+
+    4418: [744],    # Doma WOR Main Room --> Doma WoB Outside (ruination: splits indoor WoR from outdoor WoB for siege)
 }
 
 # Add forced connections for virtual doors (-dra)

--- a/event/doma_wob.py
+++ b/event/doma_wob.py
@@ -256,13 +256,14 @@ class DomaWOB(Event):
 
 
     @staticmethod
-    def entrance_door_patch(args):
+    def entrance_door_patch(args, exit_event_x=33, exit_event_y=53):
         # self-contained code to be called in door rando after entering Doma WoB
         # to be used in event_exit_info.entrance_door_patch()
+        # exit_event_x/y: LOAD_DOMA coords (normal Doma load when siege complete or gated)
+        #   Default (33,53) for door 1240 (world map entrance)
+        #   Use (28,33) for door 744 (inside main door, ruination mode)
         enter_event_x = 33
         enter_event_y = 42
-        exit_event_x = 33
-        exit_event_y = 53
         CYAN = 2
 
         src_field = []

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -151,10 +151,11 @@ ROOM_REWARD = {
     'ruin-mtek3': {"Magitek Factory_3": [RewardType.CHARACTER, RewardType.ESPER]},  # Magitek Factory 3, needs logical separation from Vector.  2nd boss where?
     
     # CYAN
-    'ms-wob-18': {"Doma WOB": [RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM]},  # Doma Siege
+    'ms-wob-18': {"Doma WOB": [RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM]},  # Doma Siege (non-ruination)
+    371: {"Doma WOB": [RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM]},  # Doma Siege (ruination)
     429: {"Doma WOR_2": [RewardType.ESPER, RewardType.ITEM]},  # Doma Dream 1: stooges
     'ruin-wrexsoul': {"Doma WOR_1": [RewardType.CHARACTER, RewardType.ESPER]},  # Doma Dream 2: Wrexsoul
-    'dc-76': {"Doma WOR_3": [RewardType.ESPER, RewardType.ITEM]},  # Doma Dream 3: throne (gated by Wrexsoul, though it's not a character so this doesn't affect gating)
+    'ruin-doma': {"Doma WOR_3": [RewardType.ESPER, RewardType.ITEM]},  # Doma Dream 3: throne (gated by Wrexsoul, though it's not a character so this doesn't affect gating)
     256: {"Mt. Zozo": [RewardType.CHARACTER, RewardType.ESPER, RewardType.ITEM]},  # Mt Zozo
     
     # SHADOW
@@ -249,7 +250,7 @@ AREA_TYPES = {
 # List of rooms associated with each named area
 RUIN_ROOM_SETS = {
     'Doma': [208, 209, 210, 211, '221R', 435, 436, '212R', 430, 431,
-                  432, 433, 184, 185, 186, 187, 188, '188B', 189, 190, 191, 192, 'ruin-wrexsoul', 'dc-76'],
+                  432, 433, 184, 185, 186, 187, 188, '188B', 189, 190, 191, 192, 'ruin-wrexsoul', 'ruin-doma', 371],
     'DreamMaze': [421, 422, 423, 424, 425, 426, 427, 428, 429],
     'UmarosCave': [364, 365, 366, '367a', '367b', '367c', 'share_east', 'share_west', 368],  # root is in Narshe
     'EsperMountain': [488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500],  # 501 excluded: shares exit 1057 with ruin_terminus_2


### PR DESCRIPTION
Split dc-76 into ruin-doma (WoR interior, exit 4418) and room 371 (WoB exterior, exits 744/1240) with forced connection 4418<-->744. This preserves WoR indoors while making the outdoor map WoB so the siege event triggers correctly via entrance_door_patch on door 744.

https://claude.ai/code/session_01WPTUS7UgGrE4t3JBwv1mUV