### PR TITLE
Fix invisible NPC block on Floating Continent esper reward (MAP_SHUFFLE)

### DIFF
--- a/event/floating_continent.py
+++ b/event/floating_continent.py
@@ -571,6 +571,8 @@ class FloatingContinent(Event):
         ]
         if self.MAP_SHUFFLE:
             escape_src = [
+                field.DeleteEntity(guest_char_id),
+                field.RefreshEntities(),
                 field.AddEsper(esper),
                 field.FinishCheck(),
                 field.Dialog(self.espers.get_receive_esper_dialog(esper)),


### PR DESCRIPTION
In escape_esper_mod(), when MAP_SHUFFLE is true, the escape_src list was completely overwritten, losing the DeleteEntity/RefreshEntities calls for guest character slot 0x0F. This left the guest character's tile-level collision active after the map transition, creating an invisible block at the character's last tile position despite no visible sprite.

https://claude.ai/code/session_01LqWJ3S1GwnK9nFdSjS33LD