### PR TITLE
Fix ruination party-state bits colliding with objective event bits

### DIFF
--- a/data/event_bit.py
+++ b/data/event_bit.py
@@ -258,7 +258,7 @@ DEFEATED_PAINTING_3 = 0x254  # beat 2nd painting in Owzer's Basement
 
 from constants.objectives import MAX_OBJECTIVES
 for index in range(MAX_OBJECTIVES):
-    globals()["OBJECTIVE" + str(index)] = 0xe0 + index
+    globals()["OBJECTIVE" + str(index)] = 0xe4 + index
 
 def byte(event_bit):
     return event_bit // 8
@@ -303,4 +303,4 @@ def multipurpose_party3_step(index):
 
 def objective(index):
     assert index >= 0 and index <= MAX_OBJECTIVES
-    return 0xe0 + index
+    return 0xe4 + index


### PR DESCRIPTION
Ruination's party-state bits (THREE_PARTIES_CREATED, PARTY_1/2/3_AWAY) were defined at event bits 0xe0-0xe3, which is the same range dynamically allocated to objectives (OBJECTIVE0-OBJECTIVE3). This caused objectives in those slots to be marked complete as soon as ruination set the party state bits, triggering rewards like Auto Mute at seed start.

Shift the objective base from 0xe0 to 0xe4 so the two ranges no longer overlap. All ASM that manipulates the party_away_byte uses ORA/AND masks on bits 0-3 only, so objective bits (now 4-7 of the same byte) are safe.

https://claude.ai/code/session_018goodNsUMAqfGM4jF1BhBd