### PR TITLE
Extract IN_WOR sync to JSR subroutine to fix BRA overflow in Finalize…

### DIFF
--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -1142,6 +1142,30 @@ class FinalizeBranchRecruit(_Instruction):
         party_away_byte = event_bit.address(event_bit.PARTY_1_AWAY)  # 0x1e9c
         current_party = 0x1a6d
 
+        # Subroutine: copy IN_WOR to PARTY_N_IN_WOR for the party slot in $12.
+        # Written as a separate JSR target to keep the main routine compact
+        # (avoids BRA distance overflow in the has_party2 branch).
+        in_wor_sync_src = [
+            asm.TDC(),
+            asm.LDA(0x12, asm.DIR),                          # A = party slot (1-3)
+            asm.CLC(),
+            asm.ADC(0x03, asm.IMM8),                         # index 4-6 for PARTY_N_IN_WOR bits
+            asm.TAX(),
+            asm.LDA(event_bit.address(event_bit.IN_WOR), asm.ABS),
+            asm.AND(1 << event_bit.bit(event_bit.IN_WOR), asm.IMM8),
+            asm.BEQ("CLEAR_IT"),
+            asm.LDA(c0.power_of_two_table, asm.LNG_X),
+            asm.TSB(party_away_byte, asm.ABS),
+            asm.RTS(),
+            "CLEAR_IT",
+            asm.LDA(c0.power_of_two_table, asm.LNG_X),
+            asm.TRB(party_away_byte, asm.ABS),
+            asm.RTS(),
+        ]
+        in_wor_sync_space = Write(Bank.C0, in_wor_sync_src,
+                                  "finalize branch recruit: sync IN_WOR subroutine")
+        in_wor_sync_addr = in_wor_sync_space.start_address
+
         src = [
             # Restore party_away_byte saved by SetupBranchRecruit.
             # Vanilla SelectParties clears bit current_party of $1E9C,
@@ -1371,24 +1395,9 @@ class FinalizeBranchRecruit(_Instruction):
             asm.ORA(c0.power_of_two_table, asm.LNG_X),      # set AWAY bit for new party
             asm.STA(party_away_byte, asm.ABS),
 
-            # === Mirror IN_WOR bit: copy IN_WOR to PARTY_N_IN_WOR for new party ($12) ===
+            # Mirror IN_WOR: copy IN_WOR to PARTY_N_IN_WOR for new party ($12)
             "SYNC_IN_WOR",
-            asm.TDC(),
-            asm.LDA(0x12, asm.DIR),                          # A = new party slot (1-3)
-            asm.CLC(),
-            asm.ADC(0x03, asm.IMM8),                         # index 4-6 for PARTY_N_IN_WOR bits
-            asm.TAX(),
-            asm.LDA(event_bit.address(event_bit.IN_WOR), asm.ABS),
-            asm.AND(1 << event_bit.bit(event_bit.IN_WOR), asm.IMM8),  # isolate IN_WOR
-            asm.BEQ("CLEAR_NEW_IN_WOR"),
-            # IN_WOR set → set PARTY_N_IN_WOR for new party
-            asm.LDA(c0.power_of_two_table, asm.LNG_X),
-            asm.TSB(party_away_byte, asm.ABS),               # same byte as PARTY_N_AWAY ($1E9C)
-            asm.BRA("STEP4_AFTER_SCRATCH"),
-            "CLEAR_NEW_IN_WOR",
-            # IN_WOR clear → clear PARTY_N_IN_WOR for new party
-            asm.LDA(c0.power_of_two_table, asm.LNG_X),
-            asm.TRB(party_away_byte, asm.ABS),               # same byte as PARTY_N_AWAY ($1E9C)
+            asm.JSR(in_wor_sync_addr, asm.ABS),
 
             asm.BRA("STEP4_AFTER_SCRATCH"),                  # skip SCRATCH clear
 


### PR DESCRIPTION
…BranchRecruit

The inline IN_WOR sync block pushed the BEQ("STEP4") branch past the 128-byte relative branch limit. Extract the sync logic into a separate JSR subroutine to reduce the inline footprint from ~40 bytes to 5.

https://claude.ai/code/session_017GLug9fAuEUweW7gexmnTn