### PR TITLE
Revert -nfce handling in ruination_map __init__; already handled by i…

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -3328,25 +3328,6 @@ class ruination_map():
         self.accessible_shops = []  # list of shop IDs that are accessible (for dried meat assignment)
         self.characters_data = characters  # Characters object for querying commands (e.g. Blitz)
 
-        if args.no_free_characters_espers:
-            # Restrict affected checks to ITEM only, matching the non-ruination event behavior
-            NFCE_RESTRICTED = {
-                'ms-wor-51': ["Collapsing House"],
-                'ruin-figarocastle': ["Figaro Castle WOB"],
-                'ms-wob-14': ["Gau Father House"],
-                'ms-wor-59': ["Kohlingen"],
-                256: ["Mt. Zozo"],
-                'ruin-narshe': ["Narshe WOR"],
-                'ms-wor-58': ["South Figaro"],
-                'ruin-lonewolf': ["Lone Wolf"],
-                'dc-73': ["Auction House_1", "Auction House_2"],
-            }
-            for room_key, reward_names in NFCE_RESTRICTED.items():
-                if room_key in ROOM_REWARD:
-                    for name in reward_names:
-                        if name in ROOM_REWARD[room_key]:
-                            ROOM_REWARD[room_key][name] = [RewardType.ITEM]
-
         # Spoiler log tracking: ordered list of reward acquisitions
         # Each entry: {'order': int, 'name': str, 'branch': int, 'type': RewardType, 'reward_id': int, 'reward_room': room_id}
         self.reward_log = []


### PR DESCRIPTION
…nit_rewards()

The NFCE_RESTRICTED block in ruination.py was overwriting ROOM_REWARD entries with plain lists before ruination_mod() in events.py replaced them with actual Reward objects, making the code both ineffective and breaking compilation. The -nfce flag is already correctly handled by each event's init_rewards() method, which restricts possible_types to RewardType.ITEM before the ruination mapping algorithm runs.

https://claude.ai/code/session_016gxmqDLcYyRsNmMtTwKZgH