### PR TITLE
Fix 42 errors in room_map_reference.json

### DIFF
--- a/claude_reference/room_map_reference.json
+++ b/claude_reference/room_map_reference.json
@@ -173,28 +173,28 @@
       "world": "WoR"
     },
     "241a": {
-      "map_id": 5,
+      "map_id": 2,
       "map_name": "",
       "world": "WoB",
-      "comment": "1"
+      "comment": "Serpent Trench #1"
     },
     "241b": {
-      "map_id": 5,
+      "map_id": 2,
       "map_name": "",
       "world": "WoB",
-      "comment": "2"
+      "comment": "Serpent Trench #2"
     },
     "241c": {
       "map_id": 5,
       "map_name": "",
       "world": "WoB",
-      "comment": "3"
+      "comment": "Serpent Trench #3"
     },
     "241d": {
       "map_id": 5,
       "map_name": "",
       "world": "WoB",
-      "comment": "3 --> Nikeah transition"
+      "comment": "Passthru room for handling ST#3 --> Nikeah transition"
     },
     "root-ze": {
       "map_id": 1,
@@ -241,7 +241,7 @@
       "map_id": 7,
       "map_name": "",
       "world": "WoB",
-      "comment": "South Figaro WoB entrance"
+      "comment": "Blackjack Engine Room"
     },
     "7": {
       "map_id": 8,
@@ -301,7 +301,7 @@
       "map_id": 20,
       "map_name": "NARSHE",
       "world": "WoB",
-      "comment": "Nikeah WoB entrance"
+      "comment": "Narshe Outside WoB"
     },
     "17": {
       "map_id": 20,
@@ -313,7 +313,7 @@
       "map_id": 20,
       "map_name": "NARSHE",
       "world": "WoB",
-      "comment": "Doma WoB entrance"
+      "comment": "Narshe South Caves Secret Passage Outside WoB"
     },
     "dc-4": {
       "map_id": 20,
@@ -415,7 +415,7 @@
       "map_id": 27,
       "map_name": "RELICS",
       "world": "WoB",
-      "comment": "Jidoor WoB entrance"
+      "comment": "Narshe Relic Shop"
     },
     "28R": {
       "map_id": 27,
@@ -475,7 +475,7 @@
       "map_id": 30,
       "map_name": "ELDER'S HOUSE",
       "world": "WoB",
-      "comment": "Tzen WoB entrance"
+      "comment": "Narshe Treasure Room"
     },
     "33R": {
       "map_id": 30,
@@ -493,7 +493,7 @@
       "map_id": 32,
       "map_name": "NARSHE",
       "world": "WoR",
-      "comment": "Albrook WoB entrance"
+      "comment": "Narshe Outside Behind Arvis to Mines WoR"
     },
     "36": {
       "map_id": 32,
@@ -523,7 +523,7 @@
       "map_id": 33,
       "map_name": "",
       "world": "WoR",
-      "comment": "Zozo WoB entrance"
+      "comment": "Narshe Northern Mines 2nd/3rd Floor Outside WoR"
     },
     "37a": {
       "map_id": 33,
@@ -619,7 +619,7 @@
       "map_id": 38,
       "map_name": "MOOGLE'S CAVE",
       "world": "WoR",
-      "comment": "Albrook WoR entrance"
+      "comment": "Narshe South Caves WoR.  Door 163 is inaccessible."
     },
     "50": {
       "map_id": 38,
@@ -661,7 +661,7 @@
       "map_id": 43,
       "map_name": "",
       "world": "WoB",
-      "comment": "Kohlingen WoR entrance"
+      "comment": "Narshe Northern Mines Main Hallway WoB"
     },
     "60": {
       "map_id": 43,
@@ -691,7 +691,7 @@
       "map_id": 49,
       "map_name": "",
       "world": "WoB",
-      "comment": "Maranda WoR entrance"
+      "comment": "Narshe Checkpoint Room WoB"
     },
     "64": {
       "map_id": 50,
@@ -703,7 +703,7 @@
       "map_id": 51,
       "map_name": "MOOGLE'S CAVE",
       "world": "WoB",
-      "comment": "Nikeah WoR entrance, pair 2"
+      "comment": "Narshe Moogle Defense WoB"
     },
     "66": {
       "map_id": 52,
@@ -745,7 +745,7 @@
       "map_id": 55,
       "map_name": "FIGARO CASTLE",
       "world": "WoB",
-      "comment": "Zozo WoR entrance"
+      "comment": "Figaro Castle Center Tower Outside"
     },
     "70R": {
       "map_id": 55,
@@ -781,7 +781,7 @@
       "map_id": 55,
       "map_name": "FIGARO CASTLE",
       "world": "WoB",
-      "comment": "Jidoor WoR entrance"
+      "comment": "Figaro Castle East Tower Outside"
     },
     "73R": {
       "map_id": 55,
@@ -799,7 +799,7 @@
       "map_id": 55,
       "map_name": "FIGARO CASTLE",
       "world": "[]",
-      "comment": "Figaro Castle world map entrances (Ancient Castle entrance 1558 locked by engine room key)"
+      "comment": "Figaro Castle world map entrances (Ancient Castle entrance 1558 locked by engine room, which is locked by Edgar)"
     },
     "74": {
       "map_id": 57,
@@ -829,7 +829,7 @@
       "map_id": 59,
       "map_name": "",
       "world": "WoB",
-      "comment": "Doma WoR entrance"
+      "comment": "Figaro Castle Foyer"
     },
     "76R": {
       "map_id": 59,
@@ -2224,13 +2224,13 @@
       "comment": "Phantom Train Car 6 Inside (map 0x097)"
     },
     "206a": {
-      "map_id": 151,
+      "map_id": 153,
       "map_name": "",
       "world": "WoB",
       "comment": "Phantom Train Car 6 Inside Right Cabin Siegfried Event"
     },
     "206b": {
-      "map_id": 151,
+      "map_id": 153,
       "map_name": "",
       "world": "WoB",
       "comment": "Phantom Train Car 6 Inside Left Cabin"
@@ -2242,13 +2242,13 @@
       "comment": "Phantom Train Car 7 Inside (map 0x097 + event_bit 0x17E)"
     },
     "207a": {
-      "map_id": 151,
+      "map_id": 153,
       "map_name": "",
       "world": "WoB",
       "comment": "Phantom Train Car 7 Inside Right Cabin"
     },
     "207b": {
-      "map_id": 151,
+      "map_id": 153,
       "map_name": "",
       "world": "WoB",
       "comment": "Phantom Train Car 7 Inside Left Cabin MIAB room"
@@ -3004,14 +3004,14 @@
       "comment": "Zozo Relic 4th Section Outside"
     },
     "307r_clock": {
-      "map_id": 221,
-      "map_name": "ZOZO",
+      "map_id": 225,
+      "map_name": "",
       "world": "[]",
       "comment": "Zozo Clock Puzzle Room West WoR INCLUDING clock logic"
     },
     "308r_clock": {
-      "map_id": 221,
-      "map_name": "ZOZO",
+      "map_id": 225,
+      "map_name": "",
       "world": "[]",
       "comment": "Zozo Clock Puzzle Room East WoR INCLUDING clock logic"
     },
@@ -3376,8 +3376,8 @@
       "comment": "Magitek Factory Upper Room"
     },
     "355a": {
-      "map_id": 262,
-      "map_name": "MAGITEK FACTORY",
+      "map_id": 272,
+      "map_name": "",
       "world": "WoB",
       "comment": "Magitek Factory Minecart Room"
     },
@@ -3493,7 +3493,7 @@
       "map_id": 281,
       "map_name": "",
       "world": "WoR",
-      "comment": "Mt Kolts 1F outside left"
+      "comment": "Umaro Cave 1st Room"
     },
     "365": {
       "map_id": 281,
@@ -3733,7 +3733,7 @@
       "map_id": 299,
       "map_name": "BASEMENT 2",
       "world": "WoR",
-      "comment": "Mt Koltz back side middle door"
+      "comment": "Darill's Tomb Dullahan Room"
     },
     "ruin-daryl": {
       "map_id": 299,
@@ -3820,26 +3820,26 @@
       "comment": "Phoenix cave interior entrance"
     },
     "branch-pc": {
-      "map_id": 315,
-      "map_name": "PHOENIX CAVE",
+      "map_id": 318,
+      "map_name": "",
       "world": "WoR",
       "comment": "Phoenix cave outside (with exit as door) treated as dead end"
     },
     "ms-wor-1554": {
-      "map_id": 315,
-      "map_name": "PHOENIX CAVE",
+      "map_id": 318,
+      "map_name": "",
       "world": "WoR",
       "comment": "Phoenix Cave"
     },
     "root-pc": {
-      "map_id": 315,
-      "map_name": "PHOENIX CAVE",
+      "map_id": 11,
+      "map_name": "",
       "world": "WoR",
       "comment": "Phoenix cave entry as door"
     },
     "wor-airship": {
-      "map_id": 315,
-      "map_name": "PHOENIX CAVE",
+      "map_id": 11,
+      "map_name": "",
       "world": "WoR"
     },
     "421": {
@@ -4146,7 +4146,7 @@
       "map_id": 351,
       "map_name": "",
       "world": "WoB",
-      "comment": "Duncan's house, north & south exits"
+      "comment": "Burning House Entry Room"
     },
     "458": {
       "map_id": 351,
@@ -4314,7 +4314,7 @@
       "map_id": 367,
       "map_name": "",
       "world": "WoR",
-      "comment": "Dream train lump-of-metal room left side"
+      "comment": "Fanatic's Tower 2nd Floor Treasure Room"
     },
     "485": {
       "map_id": 368,
@@ -4326,7 +4326,7 @@
       "map_id": 369,
       "map_name": "",
       "world": "WoR",
-      "comment": "Dream train lump-of-metal room right side"
+      "comment": "Fanatic's Tower 4th Floor Treasure Room"
     },
     "487": {
       "map_id": 370,
@@ -4344,7 +4344,7 @@
       "map_id": 372,
       "map_name": "",
       "world": "WoB",
-      "comment": "Phantom Train dining car left side"
+      "comment": "Esper Mountain Outside Bridge Room"
     },
     "490": {
       "map_id": 372,
@@ -4356,7 +4356,7 @@
       "map_id": 372,
       "map_name": "",
       "world": "WoB",
-      "comment": "Phantom Train dining car right side"
+      "comment": "Esper Mountain Outside Path to Final Room"
     },
     "492": {
       "map_id": 373,
@@ -4368,7 +4368,7 @@
       "map_id": 373,
       "map_name": "",
       "world": "WoB",
-      "comment": "Phantom Train Car 4, left exit"
+      "comment": "Esper Mountain Outside West Treasure Room"
     },
     "494": {
       "map_id": 374,
@@ -4386,13 +4386,13 @@
       "map_id": 375,
       "map_name": "",
       "world": "WoB",
-      "comment": "Phantom Train Caboose, left exit"
+      "comment": "Esper Mountain Inside Second Room South Section (with bridge jump entrances)"
     },
     "497": {
       "map_id": 375,
       "map_name": "",
       "world": "WoB",
-      "comment": "Phantom Train Caboose, right exit"
+      "comment": "Esper Mountain Falling Pit Room"
     },
     "498": {
       "map_id": 375,
@@ -4518,7 +4518,7 @@
       "map_id": 385,
       "map_name": "BASEMENT 2",
       "world": "WoB",
-      "comment": "1076 inaccessible?"
+      "comment": "Cave to Sealed Gate Lava Switch Room  # 1076 inaccessible?"
     },
     "513": {
       "map_id": 386,
@@ -4656,7 +4656,7 @@
       "map_id": 408,
       "map_name": "BASEMENT 1",
       "world": "[]",
-      "comment": "Mt. Zozo, entrance to dragon room"
+      "comment": "Ancient Castle Eastern Basement"
     },
     "532": {
       "map_id": 408,


### PR DESCRIPTION
Map ID fixes (11):
- Phantom Train cabins (206a/b, 207a/b): 151 -> 153
- Zozo clock rooms (307r_clock, 308r_clock): 221 -> 225
- Magitek Factory minecart (355a): 262 -> 272
- Phoenix Cave rooms: root-pc/wor-airship -> 11 (Falcon), branch-pc/ms-wor-1554 -> 318
- Serpent Trench (241a, 241b): 5 -> 2

Comment fixes (31):
- 25 rooms had comments drawn from shared_exits dict in rooms.py instead of room_data
- 4 Serpent Trench rooms had truncated comments
- 2 other comment corrections (room 512 prefix, ruin-figarocastle wording)

https://claude.ai/code/session_014UJnRxikgPEfsxjTTQYWoX