### PR TITLE
Fix SLI double-spacing: extend battle-bit zeroing to cover tracking r…

### DIFF
--- a/data/shops.py
+++ b/data/shops.py
@@ -388,6 +388,13 @@ class Shops():
                 break
             self.limited_shop_sram[shop_id] = self.SRAM_TRACKING_START + i
 
+        # Extend the battle-bit zeroing loop at C0/BE03 to cover the SLI tracking range.
+        # Vanilla zeroes $1DC9..$1E1C (CPX #$0054). Extend to $1DC9..$1E3F (CPX #$0077)
+        # so the tracking bytes start as zero on a new game.
+        from memory.space import Reserve
+        space = Reserve(0x00be04, 0x00be04, "extend battle bit zeroing for SLI tracking")
+        space.write(0x77)
+
     def write_limited_inventory_data(self):
         """Write pack size table and tracking pointer table to ROM."""
         from memory.space import Reserve


### PR DESCRIPTION
…ange

The SLI tracking bytes at WRAM $1E1D-$1E3F overlap with unused battle event bits that vanilla initializes to $55 (not zero). This caused every other item slot to appear "purchased" on a new game. Extend the C0/BDFF zeroing loop from CPX #$0054 to CPX #$0077 so the tracking range starts clean.

https://claude.ai/code/session_01JGMwq46URCBuR85AA72jbH