### PR TITLE
Compactify limited inventory shop item list to eliminate gaps

### DIFF
--- a/data/shops.py
+++ b/data/shops.py
@@ -422,25 +422,68 @@ class Shops():
             else:
                 space.write((0).to_bytes(2, "little"))
 
+    # Direct page addresses used for limited inventory compaction buffers.
+    # $C0-$C7: compact_items (available items packed into first N slots, rest $FF)
+    # $C8-$CF: slot_map (display position -> original shop slot index)
+    # $E1: compact mode flag (0 = normal shop, 1 = limited shop with valid buffers)
+    # $E2: temp (tracking byte during init)
+    # $E3: temp (item ID during init)
+    COMPACT_ITEMS_DP  = 0xc0   # 8 bytes: $C0-$C7
+    SLOT_MAP_DP       = 0xc8   # 8 bytes: $C8-$CF
+    COMPACT_FLAG_DP   = 0xe1   # 1 byte
+
     def disable_buy_if_empty(self):
         # in shops with no items scrolling breaks and you can buy "Empty" items
         # this function will not allow the buy menu to be selected if the shop type is empty
         from memory.space import Bank, Reserve, Write
         import instruction.asm as asm
 
-        src = [
-            asm.LDX(0x67, asm.DIR),         # x = shop index
-            asm.INX(),                      # skip shop flags byte
-            asm.LDA(0xc47ac0, asm.LNG_X),   # load first item byte
-            asm.CMP(0xff, asm.IMM8),        # is first item slot empty?
-            asm.BNE("OPEN_BUY_MENU"),       # branch if not
-            asm.JSR(0xb66f, asm.ABS),       # call invalid selection (play buzzer sound and pixelate screen)
-            asm.JMP(0xb760, asm.ABS),       # jump to return to main shop menu
+        if self.args.shop_limited_inventory:
+            # Write the compact_init subroutine first (builds compacted item list
+            # for limited shops so purchased items don't leave gaps in the menu)
+            compact_src = self._build_compact_init_asm()
+            compact_space = Write(Bank.C3, compact_src, "limited inventory: compact init subroutine")
+            compact_init_addr = compact_space.start_address
 
-            "OPEN_BUY_MENU",
-            asm.STZ(0xe0, asm.DIR),          # clear limited inventory mode flag
-            asm.JMP(0xb7a3, asm.ABS),        # jump to normal buy menu initialization
-        ]
+            src = [
+                # Check if first ROM item is empty (catches genuinely empty shops)
+                asm.LDX(0x67, asm.DIR),         # x = shop index
+                asm.INX(),                      # skip shop flags byte
+                asm.LDA(0xc47ac0, asm.LNG_X),   # load first item byte
+                asm.CMP(0xff, asm.IMM8),        # is first item slot empty?
+                asm.BNE("OPEN_BUY_MENU"),       # branch if not
+                asm.JSR(0xb66f, asm.ABS),       # buzzer
+                asm.JMP(0xb760, asm.ABS),       # return to main shop menu
+
+                "OPEN_BUY_MENU",
+                asm.STZ(0xe0, asm.DIR),          # clear limited inventory mode flag
+                asm.JSR(compact_init_addr, asm.ABS),  # build compacted item list
+                # For limited shops, check if all items have been purchased
+                asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),
+                asm.BEQ("GO"),                  # normal shop, skip check
+                asm.LDA(self.COMPACT_ITEMS_DP, asm.DIR),  # first compact item
+                asm.CMP(0xff, asm.IMM8),        # all purchased?
+                asm.BNE("GO"),
+                asm.JSR(0xb66f, asm.ABS),       # buzzer
+                asm.JMP(0xb760, asm.ABS),       # return to main shop menu
+                "GO",
+                asm.JMP(0xb7a3, asm.ABS),       # normal buy menu initialization
+            ]
+        else:
+            src = [
+                asm.LDX(0x67, asm.DIR),         # x = shop index
+                asm.INX(),                      # skip shop flags byte
+                asm.LDA(0xc47ac0, asm.LNG_X),   # load first item byte
+                asm.CMP(0xff, asm.IMM8),        # is first item slot empty?
+                asm.BNE("OPEN_BUY_MENU"),       # branch if not
+                asm.JSR(0xb66f, asm.ABS),       # buzzer
+                asm.JMP(0xb760, asm.ABS),       # return to main shop menu
+
+                "OPEN_BUY_MENU",
+                asm.STZ(0xe0, asm.DIR),          # clear limited inventory mode flag
+                asm.JMP(0xb7a3, asm.ABS),        # normal buy menu initialization
+            ]
+
         space = Write(Bank.C3, src, "shops handle buy menu empty shop")
         check_empty_shop = space.start_address
 
@@ -448,6 +491,109 @@ class Shops():
         space.write(
             (check_empty_shop & 0xffff).to_bytes(2, "little"),
         )
+
+    def _build_compact_init_asm(self):
+        """Build ASM for the compact_init subroutine.
+
+        Scans all 8 shop item slots, skips empty and purchased items,
+        and packs available items into $C0-$C7 with a slot mapping at $C8-$CF.
+        Sets $E1 = 1 if this is a limited shop (compact buffers valid).
+
+        Register contract: preserves X, Y. Uses A freely.
+        Entry: 8-bit A, 16-bit X/Y (standard menu state).
+        """
+        import instruction.asm as asm
+
+        return [
+            # Save caller's registers
+            asm.PHX(),
+            asm.PHY(),
+
+            # Clear compact mode flag
+            asm.STZ(self.COMPACT_FLAG_DP, asm.DIR),  # $E1 = 0
+
+            # Fill compact_items ($C0-$C7) and slot_map ($C8-$CF) with $FF
+            asm.LDA(0xff, asm.IMM8),
+            asm.LDX(0x000f, asm.IMM16),
+            "CLEAR",
+            asm.STA(self.COMPACT_ITEMS_DP, asm.DIR_X),  # STA $C0,X (covers $C0-$CF)
+            asm.DEX(),
+            asm.BPL("CLEAR"),
+
+            # Check if this is a limited shop
+            asm.REP(0x20),                              # 16-bit A
+            asm.LDA(0x7e0201, asm.LNG),                 # shop number
+            asm.AND(0x00ff, asm.IMM16),                  # clean high byte
+            asm.ASL(),                                   # *2 for pointer table
+            asm.TAX(),                                   # X = table offset
+            asm.LDA(self.TRACK_PTR_TABLE_SNES, asm.LNG_X),  # tracking pointer
+            asm.TAX(),                                   # X = SRAM address (or 0)
+            asm.SEP(0x20),                               # 8-bit A
+            # Z flag from TAX: set if pointer was 0 (normal shop)
+            asm.BEQ("DONE"),
+
+            # Limited shop: set flag and load tracking byte
+            asm.LDA(0x01, asm.IMM8),
+            asm.STA(self.COMPACT_FLAG_DP, asm.DIR),      # $E1 = 1
+            asm.LDA(0x7e0000, asm.LNG_X),               # tracking byte from SRAM
+            asm.STA(0xe2, asm.DIR),                      # save tracking byte
+
+            # Scan slots: Y = scan_slot (0-7), X = write_pos (0-N)
+            asm.LDX(0x0000, asm.IMM16),                  # write_pos = 0
+            asm.LDY(0x0000, asm.IMM16),                  # scan_slot = 0
+
+            "SCAN",
+            # Load item from ROM at scan_slot Y
+            # ROM index = scan_slot + $67 (16-bit shop base) + 1
+            asm.PHX(),                                   # save write_pos
+            asm.REP(0x20),                               # 16-bit A
+            asm.TYA(),                                   # A = scan_slot (16-bit, 0-7)
+            asm.CLC(),
+            asm.ADC(0x67, asm.DIR),                      # A += shop base index ($67-$68, 16-bit)
+            asm.INC(),                                   # A += 1 (skip flags byte)
+            asm.TAX(),                                   # X = ROM data offset
+            asm.SEP(0x20),                               # 8-bit A
+            asm.LDA(0xc47ac0, asm.LNG_X),               # load item from ROM
+            asm.PLX(),                                   # restore write_pos
+
+            # Check if empty in ROM
+            asm.CMP(0xff, asm.IMM8),
+            asm.BEQ("NEXT"),                             # skip empty slots
+
+            # Save item ID
+            asm.STA(0xe3, asm.DIR),
+
+            # Check tracking bit for scan_slot Y
+            asm.LDA(0xe2, asm.DIR),                      # tracking byte
+            asm.PHY(),                                   # save scan_slot
+            asm.CPY(0x0000, asm.IMM16),                  # slot 0?
+            asm.BEQ("TESTBIT"),                          # no shifting needed
+            "SHIFT",
+            asm.LSR(),                                   # shift tracking byte right
+            asm.DEY(),                                   # decrement counter
+            asm.BNE("SHIFT"),                            # loop until done
+            "TESTBIT",
+            asm.PLY(),                                   # restore scan_slot
+            asm.AND(0x01, asm.IMM8),                     # test lowest bit
+            asm.BNE("NEXT"),                             # bit set = purchased, skip
+
+            # Item is available: add to compact list
+            asm.LDA(0xe3, asm.DIR),                      # item ID
+            asm.STA(self.COMPACT_ITEMS_DP, asm.DIR_X),   # compact_items[write_pos]
+            asm.TYA(),                                   # A = scan_slot
+            asm.STA(self.SLOT_MAP_DP, asm.DIR_X),        # slot_map[write_pos]
+            asm.INX(),                                   # write_pos++
+
+            "NEXT",
+            asm.INY(),                                   # scan_slot++
+            asm.CPY(0x0008, asm.IMM16),                  # done 8 slots?
+            asm.BNE("SCAN"),                             # loop if not
+
+            "DONE",
+            asm.PLY(),                                   # restore caller's Y
+            asm.PLX(),                                   # restore caller's X
+            asm.RTS(),
+        ]
 
     def mod(self):
         self.disable_buy_if_empty()

--- a/menus/buy.py
+++ b/menus/buy.py
@@ -1,4 +1,5 @@
 from memory.space import START_ADDRESS_SNES, Bank, Reserve, Write
+from data.shops import Shops
 import instruction.asm as asm
 import args
 
@@ -6,6 +7,11 @@ class BuyMenu:
     # ROM table addresses (must match data/shops.py Shops class constants)
     PACK_SIZE_TABLE_SNES  = 0xc47fa8
     TRACK_PTR_TABLE_SNES  = 0xc48258
+
+    # Direct page addresses for compaction buffers (must match data/shops.py)
+    COMPACT_ITEMS_DP = Shops.COMPACT_ITEMS_DP   # $C0
+    SLOT_MAP_DP      = Shops.SLOT_MAP_DP         # $C8
+    COMPACT_FLAG_DP  = Shops.COMPACT_FLAG_DP     # $E1
 
     def __init__(self):
         if args.shop_limited_inventory:
@@ -20,63 +26,35 @@ class BuyMenu:
     def hook_load_item(self):
         """Hook at C3/B9AF: replace LDA $C47AC0,X with JSL to custom routine.
 
-        When loading shop items for display, checks the tracking byte in Save RAM.
-        If the item's bit is set (already purchased), returns $FF (empty) so the
-        item is hidden from the buy list.
+        If compact mode is active ($E1 != 0), reads from the pre-built compact
+        buffer at $C0-$C7 using $F1 (display position) as the index. This ensures
+        available items are packed into the first N rows with no gaps.
+
+        If compact mode is not active, loads from ROM as normal.
 
         Entry state: A=8-bit, X=16-bit, Y=16-bit
         $F1 = current menu slot (0-7)
-        X = shop data offset (shop_index + menu_slot + 1)
+        X = shop data offset (shop_index + menu_slot + 1) [unused in compact mode]
         """
         src = [
-            # Load original shop item
+            # Check if compact mode is active
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $E1
+            asm.BNE("USE_COMPACT"),
+
+            # Normal mode: load from ROM as usual
             asm.LDA(0xc47ac0, asm.LNG_X),     # Load item from ROM
-            asm.CMP(0xff, asm.IMM8),           # Empty slot?
-            asm.BEQ("RETURN"),                 # Skip check for empty items
-
-            asm.PHA(),                         # Save item ID
-            asm.PHX(),                         # Save X (16-bit)
-
-            # Look up tracking pointer for this shop
-            asm.REP(0x20),                     # 16-bit A
-            asm.LDA(0x7e0201, asm.LNG),        # Shop number
-            asm.AND(0x00ff, asm.IMM16),        # Clean to 8-bit value
-            asm.ASL(),                         # *2 for pointer table offset
-            asm.TAX(),                         # X = offset
-            asm.LDA(self.TRACK_PTR_TABLE_SNES, asm.LNG_X),  # Tracking pointer
-            asm.TAX(),                         # X = Save RAM address (or 0)
-            asm.SEP(0x20),                     # 8-bit A
-            # Z flag still reflects the 16-bit LDA result
-            asm.BEQ("RESTORE"),               # 0 = normal shop, skip
-
-            # Load tracking byte from Save RAM and test bit for menu slot
-            asm.LDA(0x7e0000, asm.LNG_X),     # Load tracking byte from WRAM
-            asm.LDX(0xf1, asm.DIR),           # X = menu slot (0-7, 16-bit load)
-            asm.BEQ("CHECK_BIT"),             # Slot 0: no shifting needed
-
-            "SHIFT_LOOP",
-            asm.LSR(),                         # Shift tracking byte right
-            asm.DEX(),                         # Counter--
-            asm.BNE("SHIFT_LOOP"),            # Loop until slot reached
-
-            "CHECK_BIT",
-            asm.AND(0x01, asm.IMM8),          # Test lowest bit
-            asm.BEQ("RESTORE"),               # Not sold, use original item
-
-            # Item is sold - return FF (empty)
-            asm.PLX(),                         # Restore X (16-bit pop)
-            asm.PLA(),                         # Discard saved item (8-bit pop)
-            asm.LDA(0xff, asm.IMM8),          # Return empty
             asm.RTL(),
 
-            "RESTORE",
-            asm.PLX(),                         # Restore X
-            asm.PLA(),                         # Restore original item
-            "RETURN",
+            # Compact mode: read from pre-built compact buffer
+            "USE_COMPACT",
+            asm.PHX(),                          # Save original X
+            asm.LDX(0xf1, asm.DIR),            # X = display position (menu slot)
+            asm.LDA(self.COMPACT_ITEMS_DP, asm.DIR_X),  # LDA $C0,X
+            asm.PLX(),                          # Restore X
             asm.RTL(),
         ]
 
-        space = Write(Bank.C3, src, "limited inventory: load shop item with tracking check")
+        space = Write(Bank.C3, src, "limited inventory: load shop item with compaction")
         custom_load_item_addr = space.start_address + START_ADDRESS_SNES
 
         # Replace the 4-byte LDA $C47AC0,X at B9AF with JSL to our routine
@@ -92,8 +70,11 @@ class BuyMenu:
         quantity ($28) and buy limit ($6A) to the pack size, and stores the
         pack size in $E0 as a "limited mode" flag for the order menu.
 
+        In compact mode, $4B is the display position. The original shop slot
+        is looked up from slot_map[$4B] at $C8+$4B.
+
         Entry state: A=8-bit, X=16-bit, Y=16-bit
-        $4B = selected cursor slot (item index in buy list)
+        $4B = selected cursor slot (display position in buy list)
         """
         src = [
             asm.JSR(0xb82f, asm.ABS),         # Call original set_buy_limit
@@ -111,18 +92,35 @@ class BuyMenu:
             asm.SEP(0x20),                     # 8-bit A
             asm.BEQ("DONE"),                  # 0 = normal shop (Z from 16-bit LDA)
 
-            # Get pack size: table index = shop_num * 8 + item_slot
+            # Resolve display position to original slot via slot_map
+            # If compact mode active, original_slot = slot_map[$4B]; else use $4B directly
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $E1
+            asm.BEQ("USE_4B"),                # not compact mode, use $4B
+            # Clean 16-bit X from $4B (only low byte is meaningful)
+            asm.REP(0x20),                     # 16-bit A
+            asm.LDA(0x4b, asm.DIR),            # A = $4B-$4C (16-bit)
+            asm.AND(0x00ff, asm.IMM16),        # clean to 0-7
+            asm.TAX(),                         # X = clean display position
+            asm.SEP(0x20),                     # 8-bit A
+            asm.LDA(self.SLOT_MAP_DP, asm.DIR_X),  # A = original slot from $C8,X
+            asm.BRA("HAVE_SLOT"),
+            "USE_4B",
+            asm.LDA(0x4b, asm.DIR),           # A = $4B (original slot = display pos)
+            "HAVE_SLOT",
+            asm.STA(0xeb, asm.DIR),            # $EB = original slot index
+
+            # Get pack size: table index = shop_num * 8 + original_slot
             asm.REP(0x20),                     # 16-bit A
             asm.LDA(0x7e0201, asm.LNG),        # Shop number
             asm.AND(0x00ff, asm.IMM16),        # Clean
             asm.ASL(),                         # *2
             asm.ASL(),                         # *4
             asm.ASL(),                         # *8
-            asm.STA(0xeb, asm.DIR),            # Temp store in $EB-$EC
-            asm.LDA(0x4b, asm.DIR),            # Item slot ($4B, 16-bit read)
-            asm.AND(0x00ff, asm.IMM16),        # Clean
+            asm.STA(0xec, asm.DIR),            # Temp store in $EC-$ED (shifted by 1 to not overwrite $EB)
+            asm.LDA(0xeb, asm.DIR),            # Original slot (in $EB; 16-bit read includes $EC)
+            asm.AND(0x00ff, asm.IMM16),        # Clean to just the slot byte
             asm.CLC(),
-            asm.ADC(0xeb, asm.DIR),            # Add shop_num * 8
+            asm.ADC(0xec, asm.DIR),            # Add shop_num * 8
             asm.TAX(),                         # X = pack table index
             asm.SEP(0x20),                     # 8-bit A
             asm.LDA(self.PACK_SIZE_TABLE_SNES, asm.LNG_X),  # Pack size
@@ -178,6 +176,9 @@ class BuyMenu:
 
         After the purchase is executed, sets the tracking bit in Save RAM
         for the purchased item slot, so it won't appear in the shop next time.
+
+        In compact mode, $4B is the display position. The original shop slot
+        is looked up from slot_map[$4B] at $C8+$4B.
         """
         src = [
             asm.JSR(0xb5b7, asm.ABS),         # Call original execute_purchase
@@ -198,9 +199,25 @@ class BuyMenu:
             asm.CPX(0x0000, asm.IMM16),       # Zero pointer? (16-bit X compare)
             asm.BEQ("DONE"),                  # Normal shop, skip
 
-            # Build bit mask for item slot $4B
+            # Resolve display position to original slot
+            asm.PHX(),                         # Save SRAM address
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $E1
+            asm.BEQ("USE_4B"),
+            # Clean 16-bit X from $4B (only low byte is meaningful)
+            asm.REP(0x20),                     # 16-bit A
+            asm.LDA(0x4b, asm.DIR),            # A = $4B-$4C (16-bit)
+            asm.AND(0x00ff, asm.IMM16),        # clean to 0-7
+            asm.TAX(),                         # X = clean display position
+            asm.SEP(0x20),                     # 8-bit A
+            asm.LDA(self.SLOT_MAP_DP, asm.DIR_X),  # A = original slot from $C8,X
+            asm.BRA("HAVE_SLOT"),
+            "USE_4B",
+            asm.LDA(0x4b, asm.DIR),           # A = $4B directly
+            "HAVE_SLOT",
+            asm.PLX(),                         # Restore SRAM address
+
+            # Build bit mask for the original item slot (in A, 0-7)
             asm.REP(0x20),                     # 16-bit A (to get clean TAY)
-            asm.LDA(0x4b, asm.DIR),            # Item slot (16-bit load from $4B-$4C)
             asm.AND(0x0007, asm.IMM16),       # Mask to 0-7 (clean both bytes)
             asm.TAY(),                         # Y = clean slot number
             asm.SEP(0x20),                     # 8-bit A


### PR DESCRIPTION
When items are purchased in limited inventory shops, the remaining items are now packed into consecutive rows at the top of the buy list. This fixes three issues:
- Blank rows appearing where purchased items were
- Unreachable items at the bottom of the list (cursor limit was correct but items had gaps)
- Character animation glitch when selecting blank rows

Implementation:
- New compact_init subroutine runs on buy menu entry: scans all 8 shop slots, builds a compacted item buffer ($C0-$C7) and a slot mapping table ($C8-$CF) that maps display position to original slot index
- hook_load_item simplified to read from compact buffer instead of ROM
- hook_buy_setup and hook_execute_buy resolve cursor position ($4B) to original slot index via slot_map for correct pack size lookup and tracking bit updates
- All-items-purchased check added to prevent entering empty buy menu

https://claude.ai/code/session_01CsB9mbnLwa5XRKvTSHkhhQ