### PR TITLE
Move cursor reset from redraw trampoline to execute_buy hook

### DIFF
--- a/data/shops.py
+++ b/data/shops.py
@@ -500,7 +500,6 @@ class Shops():
             # from post-purchase return (state 28 → B7B3 → B7BC).
             redraw_src = [
                 asm.JSR(compact_init_addr, asm.ABS),  # rebuild compact buffers
-                asm.STZ(0x4e, asm.DIR),                # reset cursor position to top
 
                 # If limited shop and all items now bought, exit to main shop menu
                 asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $25 compact mode?

--- a/menus/buy.py
+++ b/menus/buy.py
@@ -237,6 +237,7 @@ class BuyMenu:
 
             # Clear limited mode flag (will be re-set if player buys again)
             asm.STZ(self.LIMITED_MODE_DP, asm.DIR),  # Clear $30
+            asm.STZ(0x4e, asm.DIR),            # Reset cursor to top for redraw
 
             "DONE",
             asm.PLY(),


### PR DESCRIPTION
STZ $4E was firing on every buy list redraw (including when cancelling the order menu without purchasing). Move it to hook_execute_buy so the cursor only resets after an actual purchase is completed.

https://claude.ai/code/session_01CsB9mbnLwa5XRKvTSHkhhQ