### PR TITLE
Fix GP underflow in limited inventory shops by showing pack prices

### DIFF
--- a/menus/buy.py
+++ b/menus/buy.py
@@ -14,15 +14,126 @@ class BuyMenu:
     COMPACT_FLAG_DP  = Shops.COMPACT_FLAG_DP     # $25
     LIMITED_MODE_DP  = Shops.LIMITED_MODE_DP      # $30
 
+    # Free DP bytes used as temporaries for price inflation / pack lookup
+    SLOT_TEMP_DP       = 0x42   # 1 byte: temp for slot index or pack size
+    PACK_TEMP_DP       = 0x49   # 2 bytes ($49-$4A): temp for pack table computation
+    UNIT_PRICE_SAVE_DP = 0x60   # 2 bytes ($60-$61): saved unit price for restore
+
     def __init__(self):
         if args.shop_limited_inventory:
             self.mod()
 
     def mod(self):
+        # Write shared resources first
+        self._write_get_pack_subroutine()
+        self._write_qty_label_text()
+
+        # Existing hooks
         self.hook_load_item()
         self.hook_buy_setup()
         self.hook_pre_order()
         self.hook_execute_buy()
+
+        # New hooks for price display and Qty: panel
+        self.hook_price_display()
+        self.hook_affordability_restore()
+        self.hook_draw_labels()
+        self.hook_draw_qty_value()
+
+    # ------------------------------------------------------------------
+    # Shared resources
+    # ------------------------------------------------------------------
+
+    def _write_get_pack_subroutine(self):
+        """Write a reusable subroutine to Bank C3 that looks up the pack size
+        for a given display slot.
+
+        Input:  A = display slot (8-bit, 0-7)
+        Output: A = pack size (8-bit; 0 = normal shop, 1-15 = limited)
+        Clobbers: X.  Preserves: Y.
+        Entry state: 8-bit A, 16-bit X/Y.
+        """
+        src = [
+            asm.PHY(),
+            asm.STA(self.SLOT_TEMP_DP, asm.DIR),       # $42 = display slot
+
+            # Check if limited shop
+            asm.REP(0x20),                              # 16-bit A
+            asm.LDA(0x7e0201, asm.LNG),                 # shop number
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),                                   # *2
+            asm.TAX(),
+            asm.LDA(self.TRACK_PTR_TABLE_SNES, asm.LNG_X),
+            asm.SEP(0x20),                               # 8-bit A
+            asm.BEQ("RET_ZERO"),                         # Z from 16-bit LDA; 0 = normal
+
+            # Resolve display slot → original slot (if compact mode)
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),      # $25
+            asm.BEQ("DIRECT"),                           # not compact
+            asm.REP(0x20),
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.TAX(),
+            asm.SEP(0x20),
+            asm.LDA(self.SLOT_MAP_DP, asm.DIR_X),       # original slot from $B8,X
+            asm.STA(self.SLOT_TEMP_DP, asm.DIR),         # update $42
+            "DIRECT",
+
+            # Compute pack table index = shop_num * 8 + original_slot
+            asm.REP(0x20),
+            asm.LDA(0x7e0201, asm.LNG),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),
+            asm.ASL(),
+            asm.ASL(),                                   # *8
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),         # $49-$4A
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.CLC(),
+            asm.ADC(self.PACK_TEMP_DP, asm.DIR),
+            asm.TAX(),
+            asm.SEP(0x20),
+            asm.LDA(self.PACK_SIZE_TABLE_SNES, asm.LNG_X),
+
+            asm.PLY(),
+            asm.RTS(),
+
+            "RET_ZERO",
+            asm.LDA(0x00, asm.IMM8),
+            asm.PLY(),
+            asm.RTS(),
+        ]
+        space = Write(Bank.C3, src, "limited inventory: get pack size subroutine")
+        self._get_pack_addr = space.start_address   # ROM address in Bank C3
+
+    def _write_qty_label_text(self):
+        """Write the positioned text data for the 'Qty:' label to Bank C3.
+
+        Format: 2-byte tilemap position (little-endian) + text bytes + $00.
+        Position $7CB3 places the label one section below 'Equipped:' ($7BB3).
+
+        FF6 menu text encoding: A=$80..Z=$99, a=$9A..z=$B3, ':'=$C1.
+        'Qty:' = Q($90) t($AD) y($B2) :($C1)
+        """
+        qty_text = bytes([0xb3, 0x7c, 0x90, 0xad, 0xb2, 0xc1, 0x00])
+        space = Write(Bank.C3, [qty_text], "limited inventory: Qty label text data")
+        self._qty_text_addr = space.start_address   # ROM address in Bank C3
+
+    # ------------------------------------------------------------------
+    # Hook helpers
+    # ------------------------------------------------------------------
+
+    def _get_pack_addr_local(self):
+        """Bank-C3-local (16-bit) address of get_pack_size subroutine."""
+        return self._get_pack_addr & 0xffff
+
+    def _qty_text_addr_local(self):
+        """Bank-C3-local (16-bit) address of 'Qty:' text data."""
+        return self._qty_text_addr & 0xffff
+
+    # ------------------------------------------------------------------
+    # Existing hooks (unchanged)
+    # ------------------------------------------------------------------
 
     def hook_load_item(self):
         """Hook at C3/B9AF: replace LDA $C47AC0,X with JSL to custom routine.
@@ -67,12 +178,12 @@ class BuyMenu:
     def hook_buy_setup(self):
         """Hook at C3/B4DF: replace JSR $B82F with JSR to custom routine.
 
-        When player presses A on an item in the buy list, this sets the buy
-        quantity ($28) and buy limit ($6A) to the pack size, and stores the
-        pack size in $30 as a "limited mode" flag for the order menu.
-
-        In compact mode, $4B is the display position. The original shop slot
-        is looked up from slot_map[$4B] at $B8+$4B.
+        Sets $28 (qty), $6A (buy limit), and $30 (limited flag) to the pack
+        size.  Then temporarily inflates the price in $7E9F09 for the cursor
+        slot so the affordability check at B7E6 (which runs immediately after
+        this hook) compares GP against the *total pack price*, not the unit
+        price.  The original unit price is saved in $60-$61 so the next hook
+        (hook_affordability_restore) can put it back.
 
         Entry state: A=8-bit, X=16-bit, Y=16-bit
         $4B = selected cursor slot (display position in buy list)
@@ -94,10 +205,8 @@ class BuyMenu:
             asm.BEQ("DONE"),                  # 0 = normal shop (Z from 16-bit LDA)
 
             # Resolve display position to original slot via slot_map
-            # If compact mode active, original_slot = slot_map[$4B]; else use $4B directly
             asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $25
             asm.BEQ("USE_4B"),                # not compact mode, use $4B
-            # Clean 16-bit X from $4B (only low byte is meaningful)
             asm.REP(0x20),                     # 16-bit A
             asm.LDA(0x4b, asm.DIR),            # A = $4B-$4C (16-bit)
             asm.AND(0x00ff, asm.IMM16),        # clean to 0-7
@@ -108,7 +217,7 @@ class BuyMenu:
             "USE_4B",
             asm.LDA(0x4b, asm.DIR),           # A = $4B (original slot = display pos)
             "HAVE_SLOT",
-            asm.STA(0x38, asm.DIR),            # $38 = original slot index (temp, unused in shop)
+            asm.STA(0x38, asm.DIR),            # $38 = original slot index (temp)
 
             # Get pack size: table index = shop_num * 8 + original_slot
             asm.REP(0x20),                     # 16-bit A
@@ -118,7 +227,7 @@ class BuyMenu:
             asm.ASL(),                         # *4
             asm.ASL(),                         # *8
             asm.STA(0x40, asm.DIR),            # Temp store in $40-$41
-            asm.LDA(0x38, asm.DIR),            # Original slot (in $38; 16-bit read includes $39)
+            asm.LDA(0x38, asm.DIR),            # Original slot
             asm.AND(0x00ff, asm.IMM16),        # Clean to just the slot byte
             asm.CLC(),
             asm.ADC(0x40, asm.DIR),            # Add shop_num * 8
@@ -129,7 +238,69 @@ class BuyMenu:
 
             asm.STA(0x28, asm.DIR),            # Set buy quantity
             asm.STA(0x6a, asm.DIR),            # Set buy limit (locks quantity up)
-            asm.STA(self.LIMITED_MODE_DP, asm.DIR),  # Set limited mode flag/pack size ($30)
+            asm.STA(self.LIMITED_MODE_DP, asm.DIR),  # Set limited mode flag ($30)
+
+            # ---- NEW: inflate $7E9F09[$4B*2] so the GP check sees pack price ----
+            asm.STA(self.SLOT_TEMP_DP, asm.DIR),  # $42 = pack_size
+
+            # Compute X = $4B * 2 (offset into price buffer)
+            asm.REP(0x20),
+            asm.LDA(0x4b, asm.DIR),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),
+            asm.TAX(),
+
+            # Save the original unit price
+            asm.LDA(0x7e9f09, asm.LNG_X),      # 16-bit unit price
+            asm.STA(self.UNIT_PRICE_SAVE_DP, asm.DIR),  # → $60-$61
+            asm.SEP(0x20),
+
+            # 16-bit × 8-bit multiply: unit_price * pack_size
+            # Step 1: price_low * pack
+            asm.LDA(self.UNIT_PRICE_SAVE_DP, asm.DIR),     # $60 = price low byte
+            asm.STA(0x4202, asm.ABS),           # hw multiplicand
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),            # $42 = pack
+            asm.STA(0x4203, asm.ABS),           # trigger multiply
+            asm.NOP(),                          # wait for hw multiply (8 cycles)
+            asm.NOP(),
+            asm.NOP(),
+            asm.NOP(),
+            asm.LDA(0x4216, asm.ABS),           # R1_low
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $49
+            asm.LDA(0x4217, asm.ABS),           # R1_high (carry)
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $4A
+
+            # Step 2: price_high * pack
+            asm.LDA(self.UNIT_PRICE_SAVE_DP + 1, asm.DIR),  # $61 = price high byte
+            asm.STA(0x4202, asm.ABS),
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),             # $42 = pack
+            asm.STA(0x4203, asm.ABS),           # trigger multiply
+            asm.NOP(),
+            asm.NOP(),
+            asm.NOP(),
+            asm.NOP(),
+
+            # Combine: final_high = R2_low + R1_high
+            asm.CLC(),
+            asm.LDA(0x4216, asm.ABS),           # R2_low
+            asm.ADC(self.PACK_TEMP_DP + 1, asm.DIR),  # + R1_high ($4A)
+            asm.BCS("CAP_PRICE"),               # overflow → cap
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),  # $4A = final high byte
+            asm.LDA(0x4217, asm.ABS),           # R2_high
+            asm.BNE("CAP_PRICE"),               # >0 → cap
+
+            # Store inflated price: $49 = low, $4A = high
+            asm.REP(0x20),
+            asm.LDA(self.PACK_TEMP_DP, asm.DIR),  # 16-bit result from $49-$4A
+            asm.STA(0x7e9f09, asm.LNG_X),
+            asm.SEP(0x20),
+            asm.BRA("DONE"),
+
+            "CAP_PRICE",
+            asm.REP(0x20),
+            asm.LDA(0xffff, asm.IMM16),
+            asm.STA(0x7e9f09, asm.LNG_X),
+            asm.SEP(0x20),
 
             "DONE",
             asm.PLX(),
@@ -137,7 +308,7 @@ class BuyMenu:
             asm.RTS(),
         ]
 
-        space = Write(Bank.C3, src, "limited inventory: buy setup with pack size")
+        space = Write(Bank.C3, src, "limited inventory: buy setup with pack size and price inflate")
         custom_buy_setup_addr = space.start_address
 
         # Replace address in JSR $B82F at B4DF (opcode at B4DF, address at B4E0-B4E1)
@@ -254,3 +425,215 @@ class BuyMenu:
         space.write(
             (custom_execute_buy_addr & 0xffff).to_bytes(2, "little"),
         )
+
+    # ------------------------------------------------------------------
+    # New hooks for pack-price display and Qty: panel
+    # ------------------------------------------------------------------
+
+    def hook_price_display(self):
+        """Hook at C3/B9CF: replace JSR $052E with JSR to custom routine.
+
+        In the buy-list draw loop, BA0C has just computed the per-unit price
+        and stored it to $F3-$F4 (and to $7E9F09).  Before the number-to-text
+        routine ($052E) converts $F3 for display, we multiply $F3-$F4 by the
+        pack size so the player sees the *total pack cost* in the item list.
+
+        $7E9F09 is intentionally left unchanged (it keeps the unit price).
+        The affordability fix is handled separately in hook_buy_setup /
+        hook_affordability_restore.
+
+        Entry state: A=8-bit, X/Y=16-bit.  $F1 = display slot (0-7).
+        """
+        src = [
+            # Quick check: skip everything for normal shops
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $25
+            asm.BEQ("CONVERT"),
+
+            # Get pack size for current display slot $F1
+            asm.LDA(0xf1, asm.DIR),
+            asm.JSR(self._get_pack_addr_local(), asm.ABS),
+            asm.CMP(0x00, asm.IMM8),
+            asm.BEQ("CONVERT"),
+            asm.CMP(0x01, asm.IMM8),           # pack=1 → no multiply needed
+            asm.BEQ("CONVERT"),
+
+            # --- 16-bit multiply: $F3-$F4 *= pack_size (A) ---
+            asm.STA(self.SLOT_TEMP_DP, asm.DIR),  # $42 = pack_size
+
+            # Step 1: $F3 (low byte) * pack
+            asm.LDA(0xf3, asm.DIR),
+            asm.STA(0x4202, asm.ABS),           # hw multiplicand
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),
+            asm.STA(0x4203, asm.ABS),           # trigger multiply
+            asm.NOP(), asm.NOP(), asm.NOP(), asm.NOP(),
+            asm.LDA(0x4216, asm.ABS),           # R1_low
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $49
+            asm.LDA(0x4217, asm.ABS),           # R1_high
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $4A
+
+            # Step 2: $F4 (high byte) * pack
+            asm.LDA(0xf4, asm.DIR),
+            asm.STA(0x4202, asm.ABS),
+            asm.LDA(self.SLOT_TEMP_DP, asm.DIR),
+            asm.STA(0x4203, asm.ABS),
+            asm.NOP(), asm.NOP(), asm.NOP(), asm.NOP(),
+
+            # Combine: final_high = R2_low + R1_high
+            asm.CLC(),
+            asm.LDA(0x4216, asm.ABS),           # R2_low
+            asm.ADC(self.PACK_TEMP_DP + 1, asm.DIR),
+            asm.BCS("CAP"),
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),
+            asm.LDA(0x4217, asm.ABS),           # R2_high
+            asm.BNE("CAP"),
+
+            # Store result back to $F3-$F4 for $052E
+            asm.LDA(self.PACK_TEMP_DP, asm.DIR),
+            asm.STA(0xf3, asm.DIR),
+            asm.LDA(self.PACK_TEMP_DP + 1, asm.DIR),
+            asm.STA(0xf4, asm.DIR),
+            asm.BRA("CONVERT"),
+
+            "CAP",
+            asm.LDA(0xff, asm.IMM8),
+            asm.STA(0xf3, asm.DIR),
+            asm.STA(0xf4, asm.DIR),
+
+            "CONVERT",
+            asm.JMP(0x052e, asm.ABS),          # tail-call original text conversion
+        ]
+
+        space = Write(Bank.C3, src, "limited inventory: price display multiply")
+        custom_addr = space.start_address
+
+        # Replace address in JSR $052E at B9CF (opcode B9CF, address B9D0-B9D1)
+        space = Reserve(0x3b9d0, 0x3b9d1, "shop buy menu price display hook")
+        space.write(
+            (custom_addr & 0xffff).to_bytes(2, "little"),
+        )
+
+    def hook_affordability_restore(self):
+        """Hook at C3/B4E2: replace JSR $B7E6 with JSR to custom routine.
+
+        Calls the original affordability check (B7E6) which reads the inflated
+        pack price from $7E9F09.  After B7E6 returns, restores the original
+        unit price from $60-$61 so the order menu and execute-buy routines
+        continue to see the per-unit price (they multiply by $28=pack_size
+        themselves).
+
+        Entry state: 8-bit A, 16-bit X/Y.
+        """
+        src = [
+            asm.JSR(0xb7e6, asm.ABS),          # original affordability check
+
+            # Restore unit price if we're in limited mode
+            asm.LDA(self.LIMITED_MODE_DP, asm.DIR),  # $30 (set by hook_buy_setup)
+            asm.BEQ("DONE"),
+
+            asm.PHX(),
+            asm.REP(0x20),
+            asm.LDA(0x4b, asm.DIR),
+            asm.AND(0x00ff, asm.IMM16),
+            asm.ASL(),
+            asm.TAX(),
+            asm.LDA(self.UNIT_PRICE_SAVE_DP, asm.DIR),  # $60-$61 = saved unit price
+            asm.STA(0x7e9f09, asm.LNG_X),       # restore
+            asm.SEP(0x20),
+            asm.PLX(),
+
+            "DONE",
+            asm.RTS(),
+        ]
+
+        space = Write(Bank.C3, src, "limited inventory: affordability restore")
+        custom_addr = space.start_address
+
+        # Replace address in JSR $B7E6 at B4E2 (opcode B4E2, address B4E3-B4E4)
+        space = Reserve(0x3b4e3, 0x3b4e4, "shop buy menu affordability hook")
+        space.write(
+            (custom_addr & 0xffff).to_bytes(2, "little"),
+        )
+
+    def hook_draw_labels(self):
+        """Hook JSR $C2E1 at B98F and BAAB to also draw 'Qty:' label.
+
+        The original C2E1 draws 'Owned:' and 'Equipped:' in blue.  For
+        limited shops ($25 != 0), we additionally draw 'Qty:' below
+        'Equipped:' at tilemap position $7CB3.
+        """
+        qty_text_local = self._qty_text_addr_local()
+
+        src = [
+            asm.JSR(0xc2e1, asm.ABS),          # original: draw Owned:, Equipped:
+
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $25
+            asm.BEQ("DONE"),
+
+            # Draw "Qty:" in blue
+            asm.JSR(0xc2f7, asm.ABS),          # Color: Blue
+            asm.LDY(qty_text_local, asm.IMM16),
+            asm.JSR(0x02f9, asm.ABS),          # Draw positioned text
+            asm.JSR(0xc2f2, asm.ABS),          # Color: User's
+
+            "DONE",
+            asm.RTS(),
+        ]
+
+        space = Write(Bank.C3, src, "limited inventory: draw labels with Qty")
+        labels_addr = space.start_address
+
+        # Hook both call sites of JSR $C2E1
+        # Site 1: B98F (initial buy list draw)
+        space = Reserve(0x3b990, 0x3b991, "shop buy menu draw labels hook 1")
+        space.write((labels_addr & 0xffff).to_bytes(2, "little"))
+
+        # Site 2: BAAB (order menu redraw)
+        space = Reserve(0x3baac, 0x3baad, "shop buy menu draw labels hook 2")
+        space.write((labels_addr & 0xffff).to_bytes(2, "little"))
+
+    def hook_draw_qty_value(self):
+        """Hook JMP $BF69 at C3/BCAB to also draw the pack quantity.
+
+        BCA8 (draw equipped count) does JSR $BFC2 then JMP $BF69.  We replace
+        the JMP target so that after the equipped count is drawn, we also draw
+        the pack size at tilemap position $7D3F (one section below the
+        equipped count at $7C3F).
+
+        For normal shops ($25 = 0), we clear the qty area to avoid stale data.
+        """
+        src = [
+            # BF69 expects A = item ID (set by BFC2 before the JMP).
+            # We must call it first before clobbering A.
+            asm.JSR(0xbf69, asm.ABS),          # draw equipped qty (was a tail-call JMP)
+
+            asm.LDA(self.COMPACT_FLAG_DP, asm.DIR),  # $25
+            asm.BEQ("CLEAR"),
+
+            # Get pack size for cursor slot $4B
+            asm.LDA(0x4b, asm.DIR),
+            asm.JSR(self._get_pack_addr_local(), asm.ABS),
+            asm.CMP(0x00, asm.IMM8),
+            asm.BEQ("CLEAR"),
+
+            # Convert pack size to text and draw 2 digits at $7D3F
+            asm.JSR(0x04e0, asm.ABS),          # 8-bit A → 3-digit text at $F7-$F9
+            asm.LDX(0x7d3f, asm.IMM16),        # tilemap position
+            asm.JSR(0x04b6, asm.ABS),          # draw 2 digits (skip 1 leading)
+            asm.RTS(),
+
+            "CLEAR",
+            # Write two blank characters at $7D3F to clear stale data
+            asm.LDA(0xff, asm.IMM8),           # blank tile
+            asm.STA(0xf8, asm.DIR),
+            asm.STA(0xf9, asm.DIR),
+            asm.LDX(0x7d3f, asm.IMM16),
+            asm.JSR(0x04b6, asm.ABS),
+            asm.RTS(),
+        ]
+
+        space = Write(Bank.C3, src, "limited inventory: draw pack qty value")
+        qty_value_addr = space.start_address
+
+        # Replace JMP target at BCAB (opcode $4C at BCAB, address at BCAC-BCAD)
+        space = Reserve(0x3bcac, 0x3bcad, "shop buy menu draw qty value hook")
+        space.write((qty_value_addr & 0xffff).to_bytes(2, "little"))


### PR DESCRIPTION
The buy menu was showing per-unit prices but deducting pack-total GP, allowing purchases when the player couldn't afford the full pack cost. This caused a GP underflow to 9,999,999.

Changes:
- hook_price_display: multiplies displayed price by pack size so the buy list shows the total pack cost (unit_price × pack_size)
- hook_buy_setup + hook_affordability_restore: temporarily inflates the price buffer entry for the GP check, then restores the unit price so the order menu math (unit_price × qty) stays correct
- hook_draw_labels: draws a "Qty:" label below "Equipped:" on the right panel for limited shops
- hook_draw_qty_value: shows the pack size next to "Qty:" and updates on cursor movement
- Shared get_pack_size subroutine avoids duplicating the slot→pack lookup logic across multiple hooks

https://claude.ai/code/session_01RiwCCgRqT6P952Q8Xzk6Rr