### PR TITLE
Add -debug-verbose flag that routes ruin diagnostics to the spoiler log

### DIFF
--- a/args/arguments.py
+++ b/args/arguments.py
@@ -27,6 +27,8 @@ class Arguments:
         self.parser.add_argument("-url", dest = "website_url", required = False, help = "Url to the shareable link for the seed")
         self.parser.add_argument("-manifest", dest = "manifest_file", required = False, help = "Output location for api metadata")
         self.parser.add_argument("-debug", dest = "debug", action = "store_true", help = "Debug mode")
+        self.parser.add_argument("-dv", "-debug-verbose", dest = "debug_verbose", action = "store_true",
+                                 help = "Write verbose ruin-mode diagnostics to a temp file and append to the spoiler log")
         self.parser.add_argument("-sid", dest = "seed_id", action = "store_true", help = "Key used for api tracking")
 
         self.parser.add_argument("-nro", dest = "no_rom_output", action = "store_true", help = "Do not output a modified rom file")
@@ -65,6 +67,10 @@ class Arguments:
             self.output_file = f"{name}_wc_{self.seed}{ext}"
 
         if self.debug:
+            self.spoiler_log = True
+        if self.debug_verbose:
+            # -debug-verbose implies a spoiler log so the diagnostics have
+            # somewhere to be appended at the end of the compile.
             self.spoiler_log = True
 
     def _process_min_max(self, arg_name):

--- a/data/doors.py
+++ b/data/doors.py
@@ -6,6 +6,7 @@ from data.rooms import forced_connections, shared_oneways, exit_room, logical_li
 from data.map_exit_extra import exit_data, doors_WOB_WOR, eventname_to_door  # for door descriptions, WOR/WOB equivalent doors
 from data.event_exit_info import event_exit_info  # for one-way exit descriptions
 from data.walks import *
+from log.verbose import vprint
 
 ROOM_SETS = {
     'Umaro': [364, 365, 366, '367a', '367b', '367c', 'share_east', 'share_west', 368, 'root-u'],
@@ -134,8 +135,10 @@ class Doors():
     force_vanilla = False  # for debugging purposes
 
     def __init__(self, args):
-        # Verbose output controlled by -debug flag
-        self.verbose = args.debug
+        # Verbose output controlled by -debug (stdout) or -debug-verbose (temp
+        # file appended to the spoiler log). Either flag enables the verbose
+        # diagnostic prints throughout the door randomizer and related modules.
+        self.verbose = bool(getattr(args, "debug", False) or getattr(args, "debug_verbose", False))
 
         # Hard overrides for testing
         self.OVERRIDE = [
@@ -384,11 +387,11 @@ class Doors():
                 for dk in [d for d in room_data[r][0]]:
                     if dk in ignore_maps:
                         if self.verbose:
-                            print('removing ', dk, ' from ', r)
+                            vprint('removing ', dk, ' from ', r)
                         room_data[r][0].remove(dk)
                     if dk in protect_doors.keys():
                         if self.verbose:
-                            print('protecting ', dk, ' in ', r, ' --> ', protect_doors[dk])
+                            vprint('protecting ', dk, ' in ', r, ' --> ', protect_doors[dk])
                         room_data[r][0].remove(dk)
                         room_data[r][0].append(protect_doors[dk])
 
@@ -398,7 +401,7 @@ class Doors():
                     for dk in [d for d in room_data[a][0]]:
                         if dk in ignore_doors:
                             if self.verbose:
-                                print('removing ', dk, ' from ', a)
+                                vprint('removing ', dk, ' from ', a)
                             room_data[a][0].remove(dk)
 
         if self.args.map_shuffle_separate:  # -maps
@@ -645,20 +648,20 @@ class Doors():
             # print('Locked:', len(all_locked), all_locked)
 
             if self.verbose:
-                print('Now Randomizing:' , area_id)
+                vprint('Now Randomizing:' , area_id)
 
             if len(area) > 0:
 
                 # Initialize the Walk Network
                 walks = Network(area)
                 if self.verbose:
-                    print('Initial Count: ', walks.rooms.count)
+                    vprint('Initial Count: ', walks.rooms.count)
 
                 walks.ApplyImmediateKeys(self.args)
                 walks.ForceConnections(self.forcing)  # Force initial connections, if any
 
                 if self.verbose:
-                    print('Count after forced connections: ', walks.rooms.count)
+                    vprint('Count after forced connections: ', walks.rooms.count)
 
                 walks.attach_dead_ends()  # Connect all the dead ends.
 
@@ -693,7 +696,7 @@ class Doors():
                     try:
                         if self.verbose:
                             #print('\tTry', Ncount, ': start room... ', start_room_id)
-                            print('\tstarting room... ', start_room_id)
+                            vprint('\tstarting room... ', start_room_id)
                         fully_connected = connect_with_timeout(walks, self.timeout)
 
                         if fully_connected is None:
@@ -702,7 +705,7 @@ class Doors():
 
                     except Exception as e:
                         if self.verbose:
-                            print(f"Network connection failed: {e}")
+                            vprint(f"Network connection failed: {e}")
 
                 fcm_doors = [m for m in fully_connected.map[0]]
                 fcm_oneways = [m for m in fully_connected.map[1]]
@@ -729,13 +732,13 @@ class Doors():
             if remove_flag:
                 map[0].remove(m)
                 if self.verbose:
-                    print('Removing logical link: ', m)
+                    vprint('Removing logical link: ', m)
         for L in logical_links:
             if L[0] in llink.keys():
                 patched_m = [llink[L[0]], llink[L[1]]]
                 map[0].append(patched_m)
                 if self.verbose:
-                    print('Patching logical link: ', patched_m)
+                    vprint('Patching logical link: ', patched_m)
 
         # Process OVERRIDE
         for op in self.OVERRIDE:
@@ -778,7 +781,7 @@ class Doors():
         if self.match_WOB_WOR:
             # Make the WOR map match the WOB map in relevant areas
             if self.verbose:
-                print('Mapping WoR to match WoB ...')
+                vprint('Mapping WoR to match WoB ...')
             WOR_map = []
             for m in map[0]:
                 if m[0] in doors_WOB_WOR.keys():
@@ -788,8 +791,8 @@ class Doors():
         if self.force_vanilla:
             # disregard everything above.  Force vanilla connections to be written.
             if self.verbose:
-                print('OVERWRITING MAP: ')
-                print(map)
+                vprint('OVERWRITING MAP: ')
+                vprint(map)
             vanilla_map = [tuple( sorted((m[0], exit_data[m[0]][0])) ) for m in map[0]] + \
                           [tuple( sorted((m[1], exit_data[m[1]][0])) ) for m in map[0]]
             vanilla_map = list(set(vanilla_map))

--- a/data/map_events.py
+++ b/data/map_events.py
@@ -1,6 +1,7 @@
 from data.map_event import MapEvent, LongMapEvent
 from event.event import *
 import time
+from log.verbose import vprint
 
 class MapEvents():
     EVENT_COUNT = 1164
@@ -273,5 +274,5 @@ class LongMapEvents():
         pointspace = Reserve(self.POINTER_START_ADDR_LONG, self.DATA_START_ADDR_LONG, 'Long Event Pointers', 0x0)
 
         if self.verbose:
-            print('Added long event program at: ' + str(hex(space.start_address)) + ' -- ', str(hex(space.end_address)) )
+            vprint('Added long event program at: ' + str(hex(space.start_address)) + ' -- ', str(hex(space.end_address)) )
 

--- a/data/maps.py
+++ b/data/maps.py
@@ -1,4 +1,5 @@
 from data.map_property import MapProperty
+from log.verbose import vprint
 
 import data.npcs as npcs
 from data.npc import NPC
@@ -529,11 +530,11 @@ class Maps():
         # Postprocess the door map
         #import traceback
         if self.doors.verbose:
-            print("=== postprocess_door_map() CALLED ===")
+            vprint("=== postprocess_door_map() CALLED ===")
             #print("Call stack:")
             #traceback.print_stack(limit=5)
-            print(f"doors.map length: {len(self.doors.map)}, doors.map[0] length: {len(self.doors.map[0]) if len(self.doors.map) > 0 else 'N/A'}")
-            print(f"exit_data[360][0] BEFORE processing: {exit_data[360][0]}")
+            vprint(f"doors.map length: {len(self.doors.map)}, doors.map[0] length: {len(self.doors.map[0]) if len(self.doors.map) > 0 else 'N/A'}")
+            vprint(f"exit_data[360][0] BEFORE processing: {exit_data[360][0]}")
 
         self.door_map = {}
         self.trap_map = {}
@@ -553,14 +554,14 @@ class Maps():
                     is_shared = len(
                         [ses for ses in shared_exits_sets if self.door_map[m[0]] in ses and m[1] in ses]) > 0
                     if self.doors.verbose and not is_shared and not (self.door_map[m[0]] == m[1]):
-                        print('CONFLICTING EXITS: ', m[0], '-->', self.door_map[m[0]], ' vs ', m[1])
+                        vprint('CONFLICTING EXITS: ', m[0], '-->', self.door_map[m[0]], ' vs ', m[1])
                 if m[1] not in self.door_map.keys():
                     self.door_map[m[1]] = m[0]
                 else:
                     is_shared = len(
                         [ses for ses in shared_exits_sets if self.door_map[m[1]] in ses and m[0] in ses]) > 0
                     if self.doors.verbose and not is_shared and not (self.door_map[m[1]] == m[0]):
-                        print('CONFLICTING EXITS: ', m[1], '-->', self.door_map[m[1]], ' vs ', m[0])
+                        vprint('CONFLICTING EXITS: ', m[1], '-->', self.door_map[m[1]], ' vs ', m[0])
 
             # Check reciprocity
             for m in self.door_map.keys():
@@ -576,15 +577,15 @@ class Maps():
             temp = [m for m in self.door_map.keys() if
                     m + 4000 in exit_data.keys() and m + 4000 not in self.door_map.keys()]
             if self.doors.verbose:
-                print(f"Adding WoR exits for doors: {temp}")
+                vprint(f"Adding WoR exits for doors: {temp}")
             for m in temp:
                 # Add logical WoR exits to the map (with vanilla connections)
                 wor_door = m + 4000
                 wor_pair = exit_data[wor_door][0]
                 if self.doors.verbose:
-                    print(f"  WoR door {wor_door}: exit_data[{wor_door}][0] = {wor_pair}")
+                    vprint(f"  WoR door {wor_door}: exit_data[{wor_door}][0] = {wor_pair}")
                     if wor_pair >= 1281 and wor_pair <= 1300:
-                        print(f"  WARNING: WoR pair {wor_pair} is in safe_id range!")
+                        vprint(f"  WARNING: WoR pair {wor_pair} is in safe_id range!")
                 self.door_map[wor_door] = wor_pair
                 # Don't overwrite the mapping for wor_pair if it is mapped
                 if wor_pair not in exit_data.keys():
@@ -601,7 +602,7 @@ class Maps():
             # Check if any safe_id values ended up in door_map
             safe_ids_in_map = [d for d in self.door_map.keys() if 1281 <= d <= 1300]
             if safe_ids_in_map and self.doors.verbose:
-                print(f"WARNING: safe_id values in door_map after WoR exits: {safe_ids_in_map}")
+                vprint(f"WARNING: safe_id values in door_map after WoR exits: {safe_ids_in_map}")
 
             # Patch all used exits
             # Also patch exits that are logical and have different destinations than their WOB companions ...
@@ -635,7 +636,7 @@ class Maps():
             if self.args.door_randomize_dungeon_crawl or self.args.ruination_mode:
                 safe_id = max([d for d in exit_data.keys() if d < 1500])
                 if self.doors.verbose:
-                    print(f"Applying dungeon_crawl override, starting safe_id: {safe_id}")
+                    vprint(f"Applying dungeon_crawl override, starting safe_id: {safe_id}")
                 for d in dungeon_crawl_exit_destination_override.keys():
                     safe_id += 1  # get a new safe door id
 
@@ -649,7 +650,7 @@ class Maps():
                     self.exits.exit_original_data[safe_id] = this_data
                     # print('Added exit data: ', d, '-->', safe_id, ': ', this_data)
                 if self.doors.verbose:
-                    print(f"exit_data[360][0] AFTER dungeon_crawl override: {exit_data[360][0]}")
+                    vprint(f"exit_data[360][0] AFTER dungeon_crawl override: {exit_data[360][0]}")
 
             # Create a trapdoor map for reference
             for m in self.doors.map[1]:
@@ -660,32 +661,32 @@ class Maps():
         safe_ids_final = [d for d in self.door_map.keys() if 1281 <= d <= 1300]
         safe_ids_as_values = [k for k, v in self.door_map.items() if 1281 <= v <= 1300]
         if self.doors.verbose:
-            print(f"=== postprocess_door_map() FINISHED ===")
-            print(f"door_map has {len(self.door_map)} entries")
+            vprint(f"=== postprocess_door_map() FINISHED ===")
+            vprint(f"door_map has {len(self.door_map)} entries")
         if safe_ids_final and self.doors.verbose:
-            print(f"WARNING: safe_id keys in door_map: {safe_ids_final}")
+            vprint(f"WARNING: safe_id keys in door_map: {safe_ids_final}")
             for sid in safe_ids_final:
-                print(f"  door_map[{sid}] = {self.door_map[sid]}")
+                vprint(f"  door_map[{sid}] = {self.door_map[sid]}")
         if safe_ids_as_values and self.doors.verbose:
-            print(f"WARNING: safe_id VALUES in door_map: {[(k, self.door_map[k]) for k in safe_ids_as_values]}")
+            vprint(f"WARNING: safe_id VALUES in door_map: {[(k, self.door_map[k]) for k in safe_ids_as_values]}")
         if 1291 in self.door_map and self.doors.verbose:
-            print(f"CRITICAL: 1291 is in door_map! door_map[1291] = {self.door_map[1291]}")
+            vprint(f"CRITICAL: 1291 is in door_map! door_map[1291] = {self.door_map[1291]}")
         if 1291 in self.door_map.values() and self.doors.verbose:
             keys_with_1291 = [k for k, v in self.door_map.items() if v == 1291]
-            print(f"CRITICAL: 1291 is a VALUE in door_map! Keys: {keys_with_1291}")
+            vprint(f"CRITICAL: 1291 is a VALUE in door_map! Keys: {keys_with_1291}")
 
         if self.doors.verbose:
-            print('Door connections:')
+            vprint('Door connections:')
             for m in self.doors.map[0]:
                 ma = [a for a in m]
                 ma.sort()
                 # Use door_descr if available, otherwise try exit_data, otherwise show ID
                 desc0 = self.doors.door_descr.get(ma[0], exit_data.get(ma[0], [None, f'ID:{ma[0]}'])[1])
                 desc1 = self.doors.door_descr.get(ma[1], exit_data.get(ma[1], [None, f'ID:{ma[1]}'])[1])
-                print('\t' + str(ma[0]) + "<-->" + str(ma[1]) + '\t(' + desc0 + '<-->' + desc1 + ')')
-            print('One-way connections:')
+                vprint('\t' + str(ma[0]) + "<-->" + str(ma[1]) + '\t(' + desc0 + '<-->' + desc1 + ')')
+            vprint('One-way connections:')
             for m in self.doors.map[1]:
-                print('\t', m[0], " -> ", m[1])
+                vprint('\t', m[0], " -> ", m[1])
 
     def doorRandoOverride(self, newmap):
         from data.map_exit_extra import exit_data as ed
@@ -800,7 +801,7 @@ class Maps():
             for e in event_exit_info.keys():
                 if (e in used_events or e in used_exits) and event_exit_info[e][0] is None:
                     if self.doors.verbose:
-                        print('attempting to update event exit info: ', e)
+                        vprint('attempting to update event exit info: ', e)
                     # Update the event addresses
                     #mapid = event_exit_info[e][5][0]
                     #ex = event_exit_info[e][5][1]
@@ -815,7 +816,7 @@ class Maps():
                     ev = self.get_event(mapid, ex, ey)
                     event_exit_info[e][0] = ev.event_address + EVENT_CODE_START
                     if self.doors.verbose:
-                        print('Updated event exit info: ', e, hex(event_exit_info[e][0]))
+                        vprint('Updated event exit info: ', e, hex(event_exit_info[e][0]))
 
             # Connect one-way event exits using the Transitions class
             self.transitions = Transitions(self.doors.map[1], self.rom, self.exits.exit_original_data, event_exit_info, args=self.args)
@@ -960,7 +961,7 @@ class Maps():
                     # Pass the script data to exit_event_data_to_include
                     self.exit_event_data_to_include[m] = [info, 1]  # always include before transition
                     if self.doors.verbose:
-                        print('Passed exit door patch for ', str(m), ' --> ', str(map[m]))
+                        vprint('Passed exit door patch for ', str(m), ' --> ', str(map[m]))
                         # print([a.__str__() for a in info[0]])
 
         for m in entrance_door_patch.keys():
@@ -974,7 +975,7 @@ class Maps():
                     # Pass the script data to exit_event_data_to_include
                     self.exit_event_data_to_include[map[m]] = info
                     if self.doors.verbose:
-                        print('Passed entrance door patch for ', str(map[m]), ' --> ', str(m))
+                        vprint('Passed entrance door patch for ', str(map[m]), ' --> ', str(m))
                         # print([a.__str__() for a in info[0]])
 
         # Generate a final list of all exits that need to be connected
@@ -987,7 +988,7 @@ class Maps():
         door_exits = [m for m in all_exits if m < 1500]
         for m in door_exits:
             if self.doors.verbose:
-                print('Connecting: ' + str(m) + ' to ' + str(map[m]))
+                vprint('Connecting: ' + str(m) + ' to ' + str(map[m]))
                 #  + ": " + str(exit_data[m][1]) + ' to ' + str(exit_data[map[m]][1])
 
             # Get exits associated with doors m and m_conn
@@ -1013,7 +1014,7 @@ class Maps():
                 if exitA.dest_map == 0x1ff:
                     exitA.dest_map = self.exits.exit_original_data[map[m]][-1]  #exit_world[exitB_pairID]
                     if self.doors.verbose:
-                        print('Updated destination map for ', m,': 0x1ff --> ', hex(exitA.dest_map) )
+                        vprint('Updated destination map for ', m,': 0x1ff --> ', hex(exitA.dest_map) )
 
             # Write events on the exits to handle required conditions:
             self.create_exit_event(m, map[m])
@@ -1024,7 +1025,7 @@ class Maps():
         for m in transition_exits:
             # We want to accumulate them first, then write them all together to avoid conflicts.
             if self.doors.verbose:
-                print('Connecting: ' + str(m) + ' to ' + str(map[m]))
+                vprint('Connecting: ' + str(m) + ' to ' + str(map[m]))
             transition_map.append([m, map[m]])
         dt = Transitions(transition_map, self.rom, self.exits.exit_original_data, event_exit_info,
                          self.exit_event_data_to_include, args=self.args)  # self.exit_event_addr_to_call
@@ -1081,7 +1082,7 @@ class Maps():
             # Look for an existing event on this exit tile
             try:
                 if self.doors.verbose:
-                    print('looking for event at: ', hex(map_id), this_exit.x, this_exit.y, '(type ', self.exits.exit_type[d], ')')
+                    vprint('looking for event at: ', hex(map_id), this_exit.x, this_exit.y, '(type ', self.exits.exit_type[d], ')')
                 existing_event = self.get_event(map_id, this_exit.x, this_exit.y)
                 # An event already exists.  It will need to be modified.
 
@@ -1089,10 +1090,10 @@ class Maps():
                 src = [field.Call(existing_event.event_address + EVENT_CODE_START), field.Return()]
 
                 if self.doors.verbose:
-                    print('WARNING: found an existing event: ', str(hex(map_id)), ' (', str(this_exit.x), ', ',
+                    vprint('WARNING: found an existing event: ', str(hex(map_id)), ' (', str(this_exit.x), ', ',
                           str(this_exit.y),
                           '): ')
-                    print('\t(', str(existing_event.x), ', ', str(existing_event.y), '):  ',
+                    vprint('\t(', str(existing_event.x), ', ', str(existing_event.y), '):  ',
                           str(hex(existing_event.event_address)))
 
                 # delete existing event
@@ -1115,8 +1116,8 @@ class Maps():
                     this_address = self.GO_WOR_EVENT_ADDR - EVENT_CODE_START
 
                 if self.doors.verbose:
-                    print('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(this_address))
-                    print('\tReason: ', require_event_flags)
+                    vprint('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(this_address))
+                    vprint('\tReason: ', require_event_flags)
 
             else:
                 #  (5) <code required when leaving room>
@@ -1231,7 +1232,7 @@ class Maps():
 
                     src_dummy = update_parent_map_src + src[:-1] + load_destination_src + src[-1:]
                     if self.doors.verbose:
-                        print('source code at switchyard: ', [a.__str__() for a in src_dummy])
+                        vprint('source code at switchyard: ', [a.__str__() for a in src_dummy])
                     AddSwitchyardEvent(d, self, src=src_dummy)
                     # space = Write(Bank.CC, src_dummy, "Door Dummy Event " + str(d))
                     # dummy_address = space.start_address - EVENT_CODE_START
@@ -1261,9 +1262,9 @@ class Maps():
                 this_address = space.start_address - EVENT_CODE_START
 
                 if self.doors.verbose:
-                    print('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(this_address))
-                    print('\tReason: ', require_event_flags)
-                    print([str(s) for s in src])
+                    vprint('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(this_address))
+                    vprint('\tReason: ', require_event_flags)
+                    vprint([str(s) for s in src])
 
             # Write the new event on the exit
             if self.exits.exit_type[d] == 'short':
@@ -1352,11 +1353,11 @@ class Maps():
         # Look for an existing event on this exit tile
         try:
             if self.doors.verbose:
-                print('looking for event at: ', hex(map_id), this_exit.x, this_exit.y)
+                vprint('looking for event at: ', hex(map_id), this_exit.x, this_exit.y)
             existing_event = self.get_event(map_id, this_exit.x, this_exit.y)
             # An event already exists.
             if self.doors.verbose:
-                print('shared map: found an existing event at ', map_id, this_exit.x, this_exit.y,
+                vprint('shared map: found an existing event at ', map_id, this_exit.x, this_exit.y,
                       hex(existing_event.event_address))
 
             # Add Call to existing event code
@@ -1479,8 +1480,8 @@ class Maps():
             space = Write(Bank.CC, wor_src, "WOR door Event " + str(d))
             this_address = space.start_address
             if self.doors.verbose:
-                print('Writing WOR door event:', d, ' @ ', hex(this_address))
-                print('\t', [str(s) for s in wor_src])
+                vprint('Writing WOR door event:', d, ' @ ', hex(this_address))
+                vprint('\t', [str(s) for s in wor_src])
 
         src = [field.BranchIfEventBitSet(event_bit.IN_WOR, this_address)] + src
 
@@ -1489,9 +1490,9 @@ class Maps():
         tile_address = space.start_address - EVENT_CODE_START
 
         if self.doors.verbose:
-            print('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(tile_address))
-            print('\tReason: ', require_event_flags)
-            print([str(s) for s in src])
+            vprint('Writing exit event:', d, '(pair =', d_ref, ') @ ', hex(tile_address))
+            vprint('\tReason: ', require_event_flags)
+            vprint([str(s) for s in src])
 
         # Write the new event on the exit
         if self.exits.exit_type[d - 4000] == 'short':
@@ -1564,7 +1565,7 @@ class Maps():
         space = Reserve(0x040000, 0x041A0F, "Original map event pointer data", field.NOP())
 
         if self.doors.verbose:
-            print('Moved Event Trigger data to ' + str(hex(new_bank)) + ': ' + str(
+            vprint('Moved Event Trigger data to ' + str(hex(new_bank)) + ': ' + str(
                 hex(self.EVENT_PTR_START)) + ', ' + str(hex(self.events.DATA_START_ADDR)))
             # for e in range(14):
             #    print('\t' + str(e) + ' (' + str(self.events.events[e].x) + ', ' + str(self.events.events[e].y) + '): ' + str(hex(self.events.events[e].event_address)))

--- a/data/transitions.py
+++ b/data/transitions.py
@@ -8,6 +8,7 @@ from memory.space import Allocate, Bank, Free, Write, Reserve
 from data.map_exit_extra import exit_data as exit_partner
 from data.map_event import MapEvent
 from event.switchyard import SummonAirship
+from log.verbose import vprint
 
 # NOTES:
 # To be comprehensive, we should treat this the same way we treat exits:
@@ -31,6 +32,10 @@ class Transitions:
         self.transitions = []
         self.rom = rom
         self.args = args
+        # Verbose diagnostics: enabled by -debug (stdout) or -debug-verbose
+        # (temp file appended to spoiler log). Override the class default.
+        if args is not None:
+            self.verbose = bool(getattr(args, "debug", False) or getattr(args, "debug_verbose", False))
         self.include_script_data = include_script_data
         if self.include_script_data is None:
             self.include_script_data = {}
@@ -55,21 +60,21 @@ class Transitions:
 
             if flags.count(True) > 0 and soo_flag:
                 if self.verbose:
-                    print(f'Making new transition: {m[0]} -> {m[1]} (reasons: {", ".join(active_reasons)})')
+                    vprint(f'Making new transition: {m[0]} -> {m[1]} (reasons: {", ".join(active_reasons)})')
                 new_trans = Transition(m[0], m[1], rom, exit_data, event_data)
                 self.transitions.append(new_trans)
             elif self.verbose and flags.count(True) > 0 and not soo_flag:
-                print(f'Skipping transition: {m[0]} -> {m[1]} (shared_oneway, not lowest)')
+                vprint(f'Skipping transition: {m[0]} -> {m[1]} (shared_oneway, not lowest)')
 
         if self.FREE_MEMORY:
             self.free()
 
         if self.verbose:
-            print('Number of Transitions = ', len(self.transitions))
+            vprint('Number of Transitions = ', len(self.transitions))
             hexify = lambda src: [hex(a)[2:] for a in src]
             for t in self.transitions:
-                print(t.exit.id, '-->', hexify(t.exit.exit_code))
-                print(t.entr.id, '-->', hexify(t.entr.entr_code))
+                vprint(t.exit.id, '-->', hexify(t.exit.exit_code))
+                vprint(t.entr.id, '-->', hexify(t.entr.entr_code))
 
         self.mod()  # Modify the code after loading all transitions
 
@@ -214,7 +219,7 @@ class Transitions:
                             print_src += [b]
                         else:
                             print_src += [b.__str__()]
-                    print(t.exit.id, t.entr.id, ' incl. addl. data ', print_src)
+                    vprint(t.exit.id, t.entr.id, ' incl. addl. data ', print_src)
 
             # Check if updated parent map is required
             if t.exit.do_update_parent_map:
@@ -279,12 +284,12 @@ class Transitions:
                 for i in range(len(addr)):
                     if addr[i] is not None:
                         addr[i] = str(hex(addr[i]))
-                print('Writing: ', t.exit.id, ' --> ', t.entr.id,
+                vprint('Writing: ', t.exit.id, ' --> ', t.entr.id,
                       ':\n\toriginal memory addresses: ', str(addr[0]), ', ', str(addr[1]),
                       '\n\tpatches applied: ', t.patches,
                       '\n\tuse jump method: ', t.exit.use_jmp,
                       '\n\tbitstring: ', [hex(s)[2:] for s in bit_src])  # t.src
-                print('\n\tnew memory address: ', hex(new_event_address))
+                vprint('\n\tnew memory address: ', hex(new_event_address))
 
             if t.exit.use_jmp:
                 # Overwrite the Load Map command with a CALL SUBROUTINE & RETURN & NOP (B2 XX XX XX FE FD)
@@ -334,7 +339,7 @@ class Transitions:
                 new_event.event_address = new_event_address - EVENT_CODE_START
                 maps.add_event(t.exit.location[0], new_event)
                 if self.verbose:
-                    print('Added new map event: ', t.exit.location[0], new_event.x, new_event.y, hex(new_event_address))
+                    vprint('Added new map event: ', t.exit.location[0], new_event.x, new_event.y, hex(new_event_address))
 
                 # Note that if this is a door acting as a one-way, the door itself is not actually used.
 

--- a/data/walks.py
+++ b/data/walks.py
@@ -3,6 +3,7 @@ import networkx as nx
 import random
 from copy import deepcopy
 import numpy as np
+from log.verbose import vprint
 
 
 class Network:
@@ -47,25 +48,25 @@ class Network:
             if d in these_doors:
                 df = forcing[d][0]
                 if self.verbose:
-                    print('Forcing: ', d, df)
+                    vprint('Forcing: ', d, df)
                 self.connect(d, df, state=state)
                 if self.verbose:
-                    print('forcing successful.')
+                    vprint('forcing successful.')
             self.protected.add(d)
             self.protected.update(forcing[d])
         if self.verbose:
-            print('added doors to protected: ', self.protected)
+            vprint('added doors to protected: ', self.protected)
 
     def ApplyImmediateKeys(self, args):
         # Apply keys controlled by args
         for flag in keys_applied_immediately.keys():
             if self.verbose:
-                print('testing flag: ', flag, '(', getattr(args, flag), ')')
+                vprint('testing flag: ', flag, '(', getattr(args, flag), ')')
             [condition, keylist] = keys_applied_immediately[flag]
             applykeys = (getattr(args, flag) == condition)
             if applykeys:
                 if self.verbose:
-                    print('condition satisfied!')
+                    vprint('condition satisfied!')
                 for k in keylist:
                     self.apply_key(k)
 
@@ -141,7 +142,7 @@ class Network:
         # unlock any doors or traps locked by key
         room_list = [r for r in self.rooms.rooms]
         if self.verbose:
-            print('\t\tassessing key ', key, 'in rooms')   # : ', room_list)
+            vprint('\t\tassessing key ', key, 'in rooms')   # : ', room_list)
         for room_id in room_list:
             #if self.verbose:
             #    print('\t\t\t\t\t\tchecking room ', room_id)
@@ -154,36 +155,36 @@ class Network:
                     continue
                 if set(required_keys).issubset(self.keychain):
                     if self.verbose:
-                        print('\t\t\tApplying key:', required_keys, 'in room', room.id)
+                        vprint('\t\t\tApplying key:', required_keys, 'in room', room.id)
                     locked = room.locks.pop(required_keys)  # this also removes the item from room.locks
                     for item in locked:
                         if isinstance(item, str):
                             # This is a key.  Immediately apply it.
                             if self.verbose:
-                                print('\t\t\tApplying a new key:', item)
+                                vprint('\t\t\tApplying a new key:', item)
                             self.apply_key(item)
                         elif isinstance(item, dict):
                             # This is another locked item.  Should not happen with tuple keys
                             if self.verbose:
-                                print('\t\t\tApplying a new lock:', item)
+                                vprint('\t\t\tApplying a new lock:', item)
                             print('\t\t\tWARNING: found a nested lock in ', room_id,' : ', item)
                             room.add_locks(item)
                             unlockable = [k for k in item.keys() if set(k).issubset(self.keychain)]
                             for k in unlockable:
                                 # unlock the nested lock, if we already have the key.
                                 if self.verbose:
-                                    print('\t\t\talready have key ', k,', applying it')
+                                    vprint('\t\t\talready have key ', k,', applying it')
                                 self.apply_key(k)
                         elif room.element_type(item) == 0:  # item < 2000
                             # This is a door.
                             if self.verbose:
-                                print('\t\t\tadding a door...', item)
+                                vprint('\t\t\tadding a door...', item)
                             room.add_doors([item])
                             self.initially_locked_exits.add(item)
                         elif room.element_type(item) == 1:
                             # This is a trap.
                             if self.verbose:
-                                print('\t\t\tadding a trap...', item)
+                                vprint('\t\t\tadding a trap...', item)
                             room.add_traps([item])
                             self.initially_locked_exits.add(item)
                         else:
@@ -193,7 +194,7 @@ class Network:
             # Delete the key, we already have it.
             if key in room.keys:
                 if self.verbose:
-                    print('\t\t\tremoving key ', key, 'from', room.id)
+                    vprint('\t\t\tremoving key ', key, 'from', room.id)
                 room.remove(key)
 
     def get_loop(self, room_id):
@@ -376,9 +377,9 @@ class Network:
         # Attach all dead-end rooms to open connections
         dead_ends = [n for n in self.net.nodes if self.is_dead_end(n)]
         if self.verbose:
-            print('Current room ids: ', [r.id for r in self.rooms])
-            print("Attaching dead ends: ", len(dead_ends))
-            print('\t', [(self.rooms.get_room(e).id, self.rooms.get_room(e).doors) for e in dead_ends])
+            vprint('Current room ids: ', [r.id for r in self.rooms])
+            vprint("Attaching dead ends: ", len(dead_ends))
+            vprint('\t', [(self.rooms.get_room(e).id, self.rooms.get_room(e).doors) for e in dead_ends])
 
         loop_flag = len(dead_ends) > 0
         max_loop_number = 20
@@ -401,8 +402,8 @@ class Network:
                 random.shuffle(attachable_doors)
 
                 if self.verbose:
-                    print("found attachable nodes: ", len(attachable_nodes), attachable_nodes)
-                    print("...with attachable doors: ", len(attachable_doors), attachable_doors)
+                    vprint("found attachable nodes: ", len(attachable_nodes), attachable_nodes)
+                    vprint("...with attachable doors: ", len(attachable_doors), attachable_doors)
 
             for Rd_id in dead_ends:
                 Rd = self.rooms.get_room(Rd_id)
@@ -453,11 +454,11 @@ class Network:
                             if flags.count(True) > 0:
                                 # ERROR don't connect it!
                                 if self.verbose:
-                                    print('\t\tCannot connect ' + str(dd) + ' to ' + str(da) + ': ')
+                                    vprint('\t\tCannot connect ' + str(dd) + ' to ' + str(da) + ': ')
                                     if flags[0]:
-                                        print('\t\t' + str(da) + ' is locked by key ' + str(ka) + ' which is in ' + str(Rd.id) + '!')
+                                        vprint('\t\t' + str(da) + ' is locked by key ' + str(ka) + ' which is in ' + str(Rd.id) + '!')
                                     elif flags[1]:
-                                        print('\t\tall other exits from ' + str(Ra.id) + ' are locked by a key in ' + str(Rd.id) + '!')
+                                        vprint('\t\tall other exits from ' + str(Ra.id) + ' are locked by a key in ' + str(Rd.id) + '!')
                                 da = None  # Safety in case we run out of exits
                                 Ra = None
 
@@ -470,7 +471,7 @@ class Network:
                     if da is not None:
                         # Attach the doors
                         if self.verbose:
-                            print('\tConnecting: ' + str(dd) + '(' + str(Rd.id) + ') to ' + str(da) + '(' + str(Ra.id) + ')')
+                            vprint('\tConnecting: ' + str(dd) + '(' + str(Rd.id) + ') to ' + str(da) + '(' + str(Ra.id) + ')')
                         self.connect(dd, da, 'static')
 
                         # If there were any keys in the dead end, add them to the connected room
@@ -479,11 +480,11 @@ class Network:
                             ka = Ra.get_key(da)
                             for kd in Rd.keys:
                                 if self.verbose:
-                                    print('\t\tMoving key' + str(kd) + ' to room ' + str(Ra.id) + ' behind lock ' + str(ka))
+                                    vprint('\t\tMoving key' + str(kd) + ' to room ' + str(Ra.id) + ' behind lock ' + str(ka))
                                 Ra.locks[ka].append(kd)
                         elif len(Rd.keys) > 0:
                             if self.verbose:
-                                print('\t\tMoving keys to room ' + str(Ra.id) + ': ', Rd.keys)
+                                vprint('\t\tMoving keys to room ' + str(Ra.id) + ': ', Rd.keys)
                             Ra.add_keys([k for k in Rd.keys])
 
                         # Add the dead room name to the attached room
@@ -501,25 +502,25 @@ class Network:
                             # If not, remove any remaining doors.
                             more_doors = [d for d in Ra.alldoors]
                             if self.verbose:
-                                print('\t' + str(Ra.id) + ' is no longer attachable. Removing doors:', more_doors)
+                                vprint('\t' + str(Ra.id) + ' is no longer attachable. Removing doors:', more_doors)
                             for d in more_doors:
                                 if d in attachable_doors:
                                     attachable_doors.remove(d)
 
                     else:
                         if self.verbose:
-                            print('\tRan out of doors to connect',dd,'to.')
+                            vprint('\tRan out of doors to connect',dd,'to.')
 
                 else:
                     # If no attachable doors, just end.  It'll probably get straightened out in the walk.
                     #return
                     if self.verbose:
-                        print('Ran out of attachable rooms.  Moving on...')
+                        vprint('Ran out of attachable rooms.  Moving on...')
 
             # having attached all the dead ends, see if we created any & attach them if we did.
             dead_ends = [n for n in self.net.nodes if self.is_dead_end(n)]
             if self.verbose:
-                print('End of loop', loop_count, '.  Remaining dead ends:', dead_ends)
+                vprint('End of loop', loop_count, '.  Remaining dead ends:', dead_ends)
 
             if len(dead_ends) > 0:
                 loop_count += 1
@@ -527,12 +528,12 @@ class Network:
             else:
                 loop_flag = False
                 if self.verbose:
-                    print('done attaching dead ends.\n')
+                    vprint('done attaching dead ends.\n')
 
             if len(dead_ends) > 0 and self.verbose:
-                print('Current room ids: ', [r.id for r in self.rooms])
-                print("Attaching dead ends: ", len(dead_ends), '(loop', loop_count,')')
-                print('\t', [(self.rooms.get_room(e).id, self.rooms.get_room(e).doors[0]) for e in dead_ends])
+                vprint('Current room ids: ', [r.id for r in self.rooms])
+                vprint("Attaching dead ends: ", len(dead_ends), '(loop', loop_count,')')
+                vprint('\t', [(self.rooms.get_room(e).id, self.rooms.get_room(e).doors[0]) for e in dead_ends])
 
     def _rename_node(self, old_id, new_id):
         """Helper to rename a node using networkx relabeling"""
@@ -717,7 +718,7 @@ class Network:
         #if self.verbose:
         #    print('\t\tbug hunting 7: ', DiDo, DiTo, PiDo, PiTo, Rule_A, Rule_B, Rule_C, Rule_D)
         if self.verbose and (sum(total_self_count == total_count[:3]) < 3):
-            print('WARNING: total count', total_count, 'not equal to total self count', total_self_count)
+            vprint('WARNING: total count', total_count, 'not equal to total self count', total_self_count)
 
         return [
             Rule_A or Rule_B or Rule_C or Rule_D or Rule_F,
@@ -739,23 +740,23 @@ class Network:
         else:
             [invalidity, by_rules, classification, cl, td, dec] = net_state.check_network_invalidity()
             if self.verbose:
-                print('Network classification: ', classification)
+                vprint('Network classification: ', classification)
             if invalidity:
                 if self.verbose:
-                    print('\tInvalid! By rule: ',
+                    vprint('\tInvalid! By rule: ',
                           [['A','B','C','D','E','F'][i] for i in range(len(by_rules)) if by_rules[i]],
                           'in/out/either = ', td, ', deadends/other doors = ', dec)
                     for k in cl.keys():
-                        print('\t',k.id,': ', cl[k])
+                        vprint('\t',k.id,': ', cl[k])
                 raise Exception('Invalid network state.')
             else:
                 if self.verbose:
-                    print('\tValid! in/out/either = ', td, ', deadends/other doors = ', dec)
+                    vprint('\tValid! in/out/either = ', td, ', deadends/other doors = ', dec)
 
             # Get active room - now using ID instead of index
             R_active = self.rooms.get_room(self.active)
             if self.verbose:
-                print('Active node: ', R_active.id)
+                vprint('Active node: ', R_active.id)
                 #print('classified nodes: ', [r.id for r in cl.keys()])
                 #r_classified = [r for r in cl.keys() if r.id == R_active.id][0]
 
@@ -763,14 +764,14 @@ class Network:
             # Apply any keys in this node if they haven't been already
             for k in R_active.keys:
                 if self.verbose:
-                    print('Found an unused key: ', k)
+                    vprint('Found an unused key: ', k)
                 net_state.apply_key(k)
 
             # Collect possible exits
             possible_exits = [[d for d in R_active.doors], [t for t in R_active.traps]]
             if self.verbose:
-                print('Possible exits: ')
-                print('\t' + str(R_active.id) + ': ', possible_exits, ' - (', R_active.count[:3], '). K: ',
+                vprint('Possible exits: ')
+                vprint('\t' + str(R_active.id) + ': ', possible_exits, ' - (', R_active.count[:3], '). K: ',
                       R_active.keys, ', L: ', R_active.locks, '. [U/s/D]:', cl[R_active.id][4])
             for node_id in net_state.get_downstream_nodes(R_active.id):
                 # Collect exits from downstream nodes.
@@ -778,7 +779,7 @@ class Network:
                 node = self.rooms.get_room(node_id)
                 node_exits = [[d for d in node.doors], [t for t in node.traps]]
                 if self.verbose:
-                    print('\t' + str(node_id) + ': ', node_exits, ' - (', node.count[:3], '). K: ', node.keys, ', L: ',
+                    vprint('\t' + str(node_id) + ': ', node_exits, ' - (', node.count[:3], '). K: ', node.keys, ', L: ',
                           node.locks, '. [U/s/D]:', cl[node_id][4])
                 possible_exits[0] += node_exits[0]
                 possible_exits[1] += node_exits[1]
@@ -800,7 +801,7 @@ class Network:
                 R1 = net_state.rooms.get_room_from_element(d1)
                 d1_type = R1.element_type(d1)
                 if self.verbose:
-                    print('selected: ', d1, ', type ', d1_type, ' (', R1.id, ')')
+                    vprint('selected: ', d1, ', type ', d1_type, ' (', R1.id, ')')
 
                 # if d1 was in a downstream node, R1 might have a key that hasn't been used yet.
                 if R1.id is not R_active.id:
@@ -809,22 +810,22 @@ class Network:
                         # R_active is significantly upstream.  Find the traversed nodes.
                         trails = [p for p in net_state.get_upstream_paths(R1.id) if R_active.id in p]
                         if self.verbose:
-                            print('trails = ', trails)
+                            vprint('trails = ', trails)
                         trail += trails[0][:trails[0].index(R_active.id)]
                         if self.verbose:
-                            print('Traversed: ', [r for r in trail])
+                            vprint('Traversed: ', [r for r in trail])
                     # Apply any keys found along the way.
                     for Rt_id in trail:
                         Rt = self.rooms.get_room(Rt_id)
                         for k in Rt.keys:
                             if self.verbose:
-                                print('Found an unused key: ', k, 'in', Rt_id)
+                                vprint('Found an unused key: ', k, 'in', Rt_id)
                             net_state.apply_key(k)
 
                 # Collect possible entrances for d1
                 possible_entrances = []
                 if self.verbose:
-                    print('Possible entrances: (', len(net_state.net.nodes), ' rooms)')
+                    vprint('Possible entrances: (', len(net_state.net.nodes), ' rooms)')
                 for node_id in net_state.net.nodes:
                     node = self.rooms.get_room(node_id)
                     if d1_type == 0:
@@ -832,7 +833,7 @@ class Network:
                     else:
                         node_entr = [p for p in node.pits]
                     if self.verbose:
-                        print('\t' + str(node.id) + ': ', node_entr, ' - (', node.count[:3], '). K: ', node.keys,
+                        vprint('\t' + str(node.id) + ': ', node_entr, ' - (', node.count[:3], '). K: ', node.keys,
                               ', L: ', node.locks, '. [U/s/D]:', cl[node.id][4])
                     possible_entrances.extend(node_entr)
 
@@ -840,7 +841,7 @@ class Network:
                     # This should only happen for forced one-way connections.  d2 must be locked, so it's not sampled.
                     possible_entrances = [d for d in forced_connections[d1]] # fail fast!
                     if self.verbose:
-                        print('\t\tForced connection: ', possible_entrances)
+                        vprint('\t\tForced connection: ', possible_entrances)
                 else:
                     possible_entrances = [p for p in possible_entrances if p not in net_state.protected]
 
@@ -852,10 +853,10 @@ class Network:
                     try:
                         net_backup = deepcopy(net_state)
                         if self.verbose:
-                            print('\t\tTrying Connection: ', str(d1), str(d2))
+                            vprint('\t\tTrying Connection: ', str(d1), str(d2))
                         net_state.connect(d1, d2)
                         if self.verbose:
-                            print('\t\t...')
+                            vprint('\t\t...')
                         net_state = net_state.connect_network()
 
                         # up_propagate the successful connection
@@ -863,16 +864,16 @@ class Network:
 
                     except:
                         if self.verbose:
-                            print('\t\t(' + str(d1) + ',' + str(d2) + ') failed')
+                            vprint('\t\t(' + str(d1) + ',' + str(d2) + ') failed')
                         net_state = net_backup  # reset the network
 
                 # If you get here, you ran out of possible entrances.
                 if self.verbose:
-                    print('\t' + str(d1) + ' ran out of possible entrances.')
+                    vprint('\t' + str(d1) + ' ran out of possible entrances.')
                 raise Exception(str(d1) + ' ran out of possible entrances.')
 
             if self.verbose:
-                print('\t' + str(R_active.id) + ' ran out of possible exits.')
+                vprint('\t' + str(R_active.id) + ' ran out of possible exits.')
             raise Exception("Ran out of possible exits.")
 
     def plot_map(self):
@@ -1290,7 +1291,7 @@ class Room:
             key_tuple = tuple(sorted(key))
             if key_tuple in self.elements['locks']:
                 if self.verbose:
-                    print(f"Warning: Merging lock {key_tuple} in room {self.id}")
+                    vprint(f"Warning: Merging lock {key_tuple} in room {self.id}")
                 self.elements['locks'][key_tuple].extend(locked_items)
             else:
                 self.elements['locks'][key_tuple] = locked_items
@@ -1306,7 +1307,7 @@ class Room:
             if element_type != 'locks' and element_id in elements:
                 elements.remove(element_id)
                 if self.verbose:
-                    print(f"Removed {element_id} from {self.id}")
+                    vprint(f"Removed {element_id} from {self.id}")
                 return True
 
         # Check locks
@@ -1314,12 +1315,12 @@ class Room:
             if element_id in locked_items:
                 locked_items.remove(element_id)
                 if self.verbose:
-                    print(f"Removed locked item {element_id} from lock {key} in room {self.id}")
+                    vprint(f"Removed locked item {element_id} from lock {key} in room {self.id}")
                 # Remove empty locks
                 if not locked_items:
                     del self.elements['locks'][key]
                     if self.verbose:
-                        print(f"Removed empty lock {key}")
+                        vprint(f"Removed empty lock {key}")
                 return True
 
         return False

--- a/data/warps.py
+++ b/data/warps.py
@@ -7,6 +7,7 @@ from data.npc import *
 import data.npc_bit as npc_bit
 from instruction.event import EVENT_CODE_START
 from data.map_event import MapEvent
+from log.verbose import vprint
 
 KT_CHECK_ADDR = 0xa014f
 CUSTOM_WARP_HOOK = 0xa0138
@@ -39,13 +40,13 @@ class Warps():
         new_warp = Warp(event_bit, warp_code)
         self.warps.append(new_warp)
         if self.verbose:
-            print('Added custom warp: ', hex(event_bit), '@ address: ', hex(warp_code))
+            vprint('Added custom warp: ', hex(event_bit), '@ address: ', hex(warp_code))
 
     def add_bit(self, bit, setting):
         if setting in ['clear', 'set']:
             self.bits[bit] = setting
             if self.verbose:
-                print('Added custom bit set to warp: ', hex(bit), ' --> ', setting)
+                vprint('Added custom bit set to warp: ', hex(bit), ' --> ', setting)
         else:
             print('warning: bad setting', hex(bit), setting)
 
@@ -87,9 +88,9 @@ class Warps():
         space = Write(Bank.CA, src, "modified custom warp handler")
         warp_handler_addr = space.start_address
         if self.verbose:
-            print('Custom warp script:')
+            vprint('Custom warp script:')
             for s in src:
-                print('\t', s.__str__())
+                vprint('\t', s.__str__())
 
         space = Reserve(CUSTOM_WARP_HOOK, CUSTOM_WARP_HOOK+5, "branch to modified custom warp handler", field.NOP())
         space.write(field.Branch(warp_handler_addr))
@@ -239,7 +240,7 @@ class WarpPoints:
             self.make_warp_point_pair(wp, maps)
 
             if self.verbose:
-                print('Modified warp point:', wp.name)
+                vprint('Modified warp point:', wp.name)
 
         # Deconflict used npc_bits
         ### APPARENTLY maps.get_npc_count gets out of whack at some point?  I'm not sure how.
@@ -289,8 +290,8 @@ class WarpPoints:
             field.Return()
         ]
         if self.verbose:
-            print('Warp point code: ', warp_point.name)
-            print([s.__str__() for s in src])
+            vprint('Warp point code: ', warp_point.name)
+            vprint([s.__str__() for s in src])
 
         return src
 
@@ -316,8 +317,8 @@ class WarpPoints:
             field.Return(),
         ]
         if self.verbose:
-            print('Warp point pair code: ', warp_point.name)
-            print([s.__str__() for s in src])
+            vprint('Warp point pair code: ', warp_point.name)
+            vprint([s.__str__() for s in src])
         return src
 
     def warp_out_animation(self):
@@ -344,8 +345,8 @@ class WarpPoints:
         ]
         space = Write(Bank.CC, src, "Warp out animation")
         if self.verbose:
-            print('Warp out animation:  ')
-            print([s.__str__() for s in src])
+            vprint('Warp out animation:  ')
+            vprint([s.__str__() for s in src])
         return space.start_address
 
     def warp_in_animation(self):
@@ -370,8 +371,8 @@ class WarpPoints:
             field.Return()
         ]
         if self.verbose:
-            print('Warp in animation:  ')
-            print([s.__str__() for s in src])
+            vprint('Warp in animation:  ')
+            vprint([s.__str__() for s in src])
         space = Write(Bank.CC, src, "Warp in animation")
         return space.start_address
 

--- a/event/events.py
+++ b/event/events.py
@@ -4,12 +4,15 @@ import instruction.field as field
 from data.map_exit_extra import exit_data, door_to_eventname
 from data.warps import Warps, WarpPoints
 from event.ruination import *
+from log.verbose import vprint
 
 class Events():
     def __init__(self, rom, args, data):
         self.rom = rom
         self.args = args
-        self.verbose = False
+        # Verbose diagnostics: enabled by -debug (stdout) or -debug-verbose
+        # (temp file appended to spoiler log).
+        self.verbose = bool(getattr(args, "debug", False) or getattr(args, "debug_verbose", False))
 
         self.dialogs = data.dialogs
         self.characters = data.characters
@@ -58,7 +61,7 @@ class Events():
                     for loc in location_list:
                         extra_gating[loc] = self.characters.EDGAR
             if self.verbose:
-                print('Added extra gating logic:', extra_gating)
+                vprint('Added extra gating logic:', extra_gating)
 
         if self.args.ruination_mode:
             self.warp_points.mod(self.dialogs, self.maps)
@@ -171,7 +174,7 @@ class Events():
                     if extra_gate[slot.event.name()] not in characters_available:
                         extra_gate_flag = False
                         if self.verbose:
-                            print('Extra gate flag FALSE!: ', slot.event.name(), self.characters.get_available_count())
+                            vprint('Extra gate flag FALSE!: ', slot.event.name(), self.characters.get_available_count())
 
                 gate_char_available = (slot.event.character_gate() in characters_available or slot.event.character_gate() is None) \
                                       and extra_gate_flag
@@ -252,8 +255,11 @@ class Events():
         party = [self.characters.DEFAULT_NAME[c] for c in characters_available]
 
         # Initialize ruination_map object
-        # Use -debug flag to enable verbose output for map generation diagnostics
-        ruin_map = ruination_map(self.args, party, verbose=self.args.debug, characters=self.characters)
+        # Verbose output for map generation diagnostics is enabled by either
+        # -debug (prints to stdout) or -debug-verbose (prints to a temp file
+        # that is appended to the spoiler log at the end of the compile).
+        ruin_verbose = bool(self.args.debug or getattr(self.args, "debug_verbose", False))
+        ruin_map = ruination_map(self.args, party, verbose=ruin_verbose, characters=self.characters)
 
         # Build out the map & distribute characters
         # Note: reward_slots are updated automatically via shared object references (see generate_map_with_characters docstring)

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -4,6 +4,7 @@ from data.rooms import room_data, ruination_dont_force, shared_exits
 from data.walks import *
 from data.characters import Characters
 import random
+from log.verbose import vprint
 
 
 class RuinationMappingError(Exception):
@@ -347,7 +348,7 @@ class RuinationBranch(Network):
             hub_room = self.rooms.get_room(hub_room_id)
             hub_room.add_pits([3039])
             if self.verbose:
-                print('CUSTOM add pit 3039 to', hub_room_id, '!', hub_room.count, hub_room.pits)
+                vprint('CUSTOM add pit 3039 to', hub_room_id, '!', hub_room.count, hub_room.pits)
             self.rooms.reindex_room(hub_room_id)
 
     def classify_rooms(self, rooms):
@@ -414,7 +415,7 @@ class RuinationBranch(Network):
     def get_all_check_connections(self, element_type=0):
         conns = set()
         if self.verbose:
-            print('Looking for check rooms...', self.check_rooms)
+            vprint('Looking for check rooms...', self.check_rooms)
         for room_id in self.check_rooms:
             room = self.rooms.get_room(room_id)
             if element_type == 0:
@@ -504,10 +505,10 @@ class RuinationBranch(Network):
                 total_pits += len([p for p in room.pits if p not in self.protected])
 
             if self.verbose:
-                print(f'  [{step_name}] Hub network totals: doors={total_doors}, traps={total_traps}, pits={total_pits}')
-                print(f'  [{step_name}] Hub {hub_id}: doors={hub_doors}, traps={hub_traps}, pits={hub_pits}')
-                print(f'  [{step_name}] Upstream nodes: {list(upstream)}')
-                print(f'  [{step_name}] Downstream nodes: {list(downstream)}')
+                vprint(f'  [{step_name}] Hub network totals: doors={total_doors}, traps={total_traps}, pits={total_pits}')
+                vprint(f'  [{step_name}] Hub {hub_id}: doors={hub_doors}, traps={hub_traps}, pits={hub_pits}')
+                vprint(f'  [{step_name}] Upstream nodes: {list(upstream)}')
+                vprint(f'  [{step_name}] Downstream nodes: {list(downstream)}')
 
         if remaining_doors is not None and dead_ends is not None:
             door_count = len(remaining_doors)
@@ -515,7 +516,7 @@ class RuinationBranch(Network):
             excess = door_count - dead_end_count
 
             if self.verbose:
-                print(f'  [{step_name}] remaining_doors={door_count}, dead_ends={dead_end_count}, excess={excess}')
+                vprint(f'  [{step_name}] remaining_doors={door_count}, dead_ends={dead_end_count}, excess={excess}')
 
             if excess > 0 and excess % 2 == 1:
                 issues.append(f'Odd excess doors ({excess}): will have orphan door after pairing')
@@ -525,13 +526,13 @@ class RuinationBranch(Network):
             pit_count = len(all_pits)
 
             if self.verbose:
-                print(f'  [{step_name}] all_traps={trap_count}, all_pits={pit_count}')
+                vprint(f'  [{step_name}] all_traps={trap_count}, all_pits={pit_count}')
 
             if trap_count > pit_count:
                 issues.append(f'More traps ({trap_count}) than pits ({pit_count})')
 
         if issues and self.verbose:
-            print(f'  [{step_name}] POTENTIAL ISSUES: {issues}')
+            vprint(f'  [{step_name}] POTENTIAL ISSUES: {issues}')
 
         return issues
 
@@ -1851,10 +1852,10 @@ class RuinationBranch(Network):
             return
 
         if self.verbose:
-            print('\t=== NO DOORS FOR TERMINUS FIX ===')
-            print(f'\tTerminus {self.terminus} not merged, but network has no doors')
-            print(f'\tAvailable traps: {all_traps}')
-            print(f'\tSearching for room with pit, door, and another exit...')
+            vprint('\t=== NO DOORS FOR TERMINUS FIX ===')
+            vprint(f'\tTerminus {self.terminus} not merged, but network has no doors')
+            vprint(f'\tAvailable traps: {all_traps}')
+            vprint(f'\tSearching for room with pit, door, and another exit...')
 
         # Find a suitable room: has pit (to receive trap), door (to add to network),
         # and at least one other exit (door or trap) so connecting doesn't dead-end
@@ -1877,14 +1878,14 @@ class RuinationBranch(Network):
             if len(unprotected_pits) >= 1 and len(unprotected_doors) >= 1 and total_exits >= 2:
                 suitable_room = room_id
                 if self.verbose:
-                    print(f'\tFound suitable room in network: {room_id}')
-                    print(f'\t  pits={unprotected_pits}, doors={unprotected_doors}, traps={unprotected_traps}')
+                    vprint(f'\tFound suitable room in network: {room_id}')
+                    vprint(f'\t  pits={unprotected_pits}, doors={unprotected_doors}, traps={unprotected_traps}')
                 break
 
         # If no suitable room in network, check reserve areas
         if suitable_room is None and reserve_areas is not None:
             if self.verbose:
-                print('\tNo suitable room in network, checking reserve areas...')
+                vprint('\tNo suitable room in network, checking reserve areas...')
 
             for area_name, area_rooms in reserve_areas:
                 for room_id in area_rooms:
@@ -1902,8 +1903,8 @@ class RuinationBranch(Network):
                             area_rooms.remove(room_id)
                             suitable_room = room_id
                             if self.verbose:
-                                print(f'\tAdded suitable room from area {area_name}: {room_id}')
-                                print(f'\t  pits={pits}, doors={doors}, traps={traps}')
+                                vprint(f'\tAdded suitable room from area {area_name}: {room_id}')
+                                vprint(f'\t  pits={pits}, doors={doors}, traps={traps}')
                             break
                 if suitable_room is not None:
                     break
@@ -1950,7 +1951,7 @@ class RuinationBranch(Network):
         selected_pit = random.choice(suitable_pits)
 
         if self.verbose:
-            print(f'\tConnecting trap {selected_trap} --> pit {selected_pit} (room {suitable_room})')
+            vprint(f'\tConnecting trap {selected_trap} --> pit {selected_pit} (room {suitable_room})')
 
         self.connect(selected_trap, selected_pit)
 
@@ -1963,21 +1964,21 @@ class RuinationBranch(Network):
             for node in downstream:
                 room = self.rooms.get_room(node)
                 new_doors.extend([d for d in room.doors if d not in self.protected])
-            print(f'\tAfter fix: network now has {len(new_doors)} doors')
+            vprint(f'\tAfter fix: network now has {len(new_doors)} doors')
 
     def finalize_map(self, reserve_areas=None):
         if self.verbose:
-            print('Closing branch...')
+            vprint('Closing branch...')
             try:
                 viz = self.visualize_branch_topology()
-                print(viz)
+                vprint(viz)
             except:
-                print('Could not visualise branch!')
+                vprint('Could not visualise branch!')
 
         self.ForceConnections(forced_connections)
 
         if self.verbose:
-            print(f'\tProtected elements after ForceConnections: {sorted(self.protected)}')
+            vprint(f'\tProtected elements after ForceConnections: {sorted(self.protected)}')
 
         # PRE-CHECK: Handle "no doors but terminus unconnected" edge case
         # This happens when the branch has only traps/pits with no remaining doors.
@@ -1993,12 +1994,12 @@ class RuinationBranch(Network):
         while finalize_iteration < max_finalize_iterations:
             finalize_iteration += 1
             if finalize_iteration > 1 and self.verbose:
-                print(f'\n=== Finalize iteration {finalize_iteration} (new elements were unlocked) ===\n')
+                vprint(f'\n=== Finalize iteration {finalize_iteration} (new elements were unlocked) ===\n')
 
             hub_id = [n for n in self.net.nodes if 'ruin_hub_' in str(n)][0]
             hub = self.rooms.get_room(hub_id)
             if self.verbose:
-                print('\thub:', hub_id, hub.count)
+                vprint('\thub:', hub_id, hub.count)
 
             # (1) Count trapdoors/pits connected to hub.  If trapdoors > pits, connect traps to rooms with (# pits > # traps).
             # Filter out protected elements to avoid using forced connection destinations
@@ -2009,7 +2010,7 @@ class RuinationBranch(Network):
             filtered_pits = [p for p in hub.pits if p in self.protected]
             filtered_traps = [t for t in hub.traps if t in self.protected]
             if self.verbose and (filtered_pits or filtered_traps):
-                print(f'\t(hub) Filtered out protected - pits: {filtered_pits}, traps: {filtered_traps}')
+                vprint(f'\t(hub) Filtered out protected - pits: {filtered_pits}, traps: {filtered_traps}')
 
             upstream = self.get_upstream_nodes(hub_id)
             for node in upstream:
@@ -2024,20 +2025,20 @@ class RuinationBranch(Network):
                 all_traps.extend([t for t in room.traps if t not in self.protected])
 
             if self.verbose:
-                print('\tpits:', all_pits)
-                print('\ttraps:', all_traps)
+                vprint('\tpits:', all_pits)
+                vprint('\ttraps:', all_traps)
 
             while len(all_traps) > len(all_pits):
                 # Find unconnected rooms with more pits than traps
                 if self.verbose:
-                    print('(1) assessing nodes for (more pits than traps):')
+                    vprint('(1) assessing nodes for (more pits than traps):')
                 winner = ''
                 diff = 0
                 for n in self.net.nodes:
                     if n not in upstream and n not in downstream and n != hub_id:
                         r = self.rooms.get_room(n)
                         if self.verbose:
-                            print('\t',n, r.count, r.doors, r.traps, r.pits, r.keys, r.locks)
+                            vprint('\t',n, r.count, r.doors, r.traps, r.pits, r.keys, r.locks)
                         # Skip rooms with no originally-free exits (all exits were key-unlocked)
                         orig_free_exits = (
                             len([d for d in r.doors if d not in self.protected
@@ -2057,7 +2058,7 @@ class RuinationBranch(Network):
                 # Fallback: search reserve areas for a room with more pits than traps
                 if winner == '' and reserve_areas is not None:
                     if self.verbose:
-                        print('(1) no suitable node in network, checking reserve areas...')
+                        vprint('(1) no suitable node in network, checking reserve areas...')
                     best_diff = 0
                     best_rid = None
                     best_area_rooms = None
@@ -2080,7 +2081,7 @@ class RuinationBranch(Network):
                         best_area_rooms.remove(best_rid)
                         winner = best_rid
                         if self.verbose:
-                            print(f'(1) added room from reserve area {best_area}: {best_rid}')
+                            vprint(f'(1) added room from reserve area {best_area}: {best_rid}')
 
                 # connect a hub trapdoor to this node
                 this_exit = random.choice(all_traps)
@@ -2089,10 +2090,10 @@ class RuinationBranch(Network):
                 this_entr = random.choice(unprotected_room_pits)
                 if self.verbose:
                     protected_in_room = [p for p in room.pits if p in self.protected]
-                    print(f'(1) selected {winner}: traps={room.traps}, pits={room.pits}')
+                    vprint(f'(1) selected {winner}: traps={room.traps}, pits={room.pits}')
                     if protected_in_room:
-                        print(f'    (filtered protected pits: {protected_in_room})')
-                    print(f'(1) connecting {this_exit} --> {this_entr}')
+                        vprint(f'    (filtered protected pits: {protected_in_room})')
+                    vprint(f'(1) connecting {this_exit} --> {this_entr}')
 
                 self.connect(this_exit, this_entr)
 
@@ -2125,7 +2126,7 @@ class RuinationBranch(Network):
                 exit_count = len(room.doors) + len(room.traps)
                 delta.append((entrance_count - exit_count, node))
             if self.verbose:
-                print('(2) delta values:', delta)
+                vprint('(2) delta values:', delta)
             # Fix A: Sort so trap-bearing rooms are processed BEFORE door-only rooms.
             # Since pop() takes from the end, trap-bearing rooms must sort last.
             # Secondary sort by delta value within each group.
@@ -2140,13 +2141,13 @@ class RuinationBranch(Network):
                 node = value[1]
                 room = self.rooms.get_room(node)
                 if self.verbose:
-                    print('(2) selected', node, '(delta = ', value[0], '): ', room.count, room.doors, room.traps, room.pits)
+                    vprint('(2) selected', node, '(delta = ', value[0], '): ', room.count, room.doors, room.traps, room.pits)
 
                 # Skip rooms with no exits (only pit entrances) - they can't connect upstream
                 # Their pits will be connected when traps are processed in step (3)
                 if len(room.doors) == 0 and len(room.traps) == 0:
                     if self.verbose:
-                        print('(2) skipping - room has no exits (pit-only)')
+                        vprint('(2) skipping - room has no exits (pit-only)')
                     continue
 
                 upstream_doors = [d for d in hub.doors if d not in self.protected]
@@ -2186,8 +2187,8 @@ class RuinationBranch(Network):
                                 # (1+ pit, 1+ door, 1+ other exit) so the trap connects
                                 # to its pit, and its door can serve the terminus.
                                 if self.verbose:
-                                    print(f'(2) Terminus unconnected, trap connection would leave 0 accessible exits.')
-                                    print(f'    Searching for converter room (1+ pit, 1+ door, 1+ other exit)...')
+                                    vprint(f'(2) Terminus unconnected, trap connection would leave 0 accessible exits.')
+                                    vprint(f'    Searching for converter room (1+ pit, 1+ door, 1+ other exit)...')
 
                                 connected_set = {hub_id} | set(upstream) | set(downstream)
                                 # Search unconnected rooms in network
@@ -2203,7 +2204,7 @@ class RuinationBranch(Network):
                                     if len(n_pits) >= 1 and len(n_doors) >= 1 and (len(n_doors) + len(n_traps)) >= 2:
                                         this_conn = random.choice(n_pits)
                                         if self.verbose:
-                                            print(f'    Found converter room {node_id} in network')
+                                            vprint(f'    Found converter room {node_id} in network')
                                         break
 
                                 # Fallback: search reserve areas
@@ -2224,7 +2225,7 @@ class RuinationBranch(Network):
                                                     added_pits = [p for p in added_room.pits if p not in self.protected]
                                                     this_conn = random.choice(added_pits)
                                                     if self.verbose:
-                                                        print(f'    Added converter room {rid} from {area_name}')
+                                                        vprint(f'    Added converter room {rid} from {area_name}')
                                                     break
                                         if this_conn is not None:
                                             break
@@ -2243,7 +2244,7 @@ class RuinationBranch(Network):
                     total_branch_doors = len(all_branch_doors)
                     if total_branch_doors <= 2 and reserve_areas is not None:
                         if self.verbose:
-                            print(f'(2) Fix B: only {total_branch_doors} doors remain in branch, '
+                            vprint(f'(2) Fix B: only {total_branch_doors} doors remain in branch, '
                                   f'searching for hub room (3+ doors) in reserve...')
                         hub_room_found = False
                         for area_name, area_rooms in reserve_areas:
@@ -2261,7 +2262,7 @@ class RuinationBranch(Network):
                                         this_conn = random.choice(unprotected_hub_doors)
                                         this_exit = random.choice(unprotected_room_doors)
                                         if self.verbose:
-                                            print(f'(2) Fix B: added hub room {rid} from {area_name} '
+                                            vprint(f'(2) Fix B: added hub room {rid} from {area_name} '
                                                   f'({len(r_doors)} doors), connecting {this_exit} --> {this_conn}')
                                         self.connect(this_exit, this_conn)
                                         hub_room_found = True
@@ -2281,19 +2282,19 @@ class RuinationBranch(Network):
                     # In such a case, we can look at unused rooms, find a converter, attach it, and try again.
                     available_nodes = [n for n in self.net.nodes if n not in self.dead_ends and n != hub_id]
                     if self.verbose:
-                        print(f'\t(2) converter search: room_traps={unprotected_room_traps}, room_doors={unprotected_room_doors}')
-                        print(f'\t    upstream_doors={upstream_doors}, upstream_pits={upstream_pits}')
-                        print(f'\t    available_nodes in network: {len(available_nodes)}')
+                        vprint(f'\t(2) converter search: room_traps={unprotected_room_traps}, room_doors={unprotected_room_doors}')
+                        vprint(f'\t    upstream_doors={upstream_doors}, upstream_pits={upstream_pits}')
+                        vprint(f'\t    available_nodes in network: {len(available_nodes)}')
                         if reserve_areas is not None:
                             ra_summary = [(a, len(r)) for a, r in reserve_areas if len(r) > 0]
-                            print(f'\t    reserve_areas: {ra_summary}')
+                            vprint(f'\t    reserve_areas: {ra_summary}')
                         else:
-                            print(f'\t    reserve_areas: None')
+                            vprint(f'\t    reserve_areas: None')
                     if len(unprotected_room_traps) > 0 and len(upstream_pits) == 0 and len(upstream_doors) > 0:
                         # Need a pit-in, door-out converter
                         pido = []
                         if self.verbose:
-                            print('\t\tlooking for available pido nodes:')
+                            vprint('\t\tlooking for available pido nodes:')
                         for node_id in available_nodes:
                             node = self.rooms.get_room(node_id)
                             unprotected_node_pits = [p for p in node.pits if p not in self.protected]
@@ -2302,7 +2303,7 @@ class RuinationBranch(Network):
                             if len(unprotected_node_pits) > 0 and len(unprotected_node_doors) > 0 and len(unprotected_node_pits) > len(unprotected_node_traps):
                                 pido.append(node_id)
                                 if self.verbose:
-                                    print('\t\t\t', node_id, ': ', node.count)
+                                    vprint('\t\t\t', node_id, ': ', node.count)
 
                         if len(pido) > 0:
                             pido_room_id = random.choice(pido)
@@ -2314,7 +2315,7 @@ class RuinationBranch(Network):
                         # Fallback: search reserve areas for a pido room
                         if len(pido) == 0 and reserve_areas is not None:
                             if self.verbose:
-                                print('\t\tno pido in network, checking reserve areas...')
+                                vprint('\t\tno pido in network, checking reserve areas...')
                             for area_name, area_rooms in reserve_areas:
                                 for rid in area_rooms:
                                     if rid in self.net.nodes:
@@ -2331,7 +2332,7 @@ class RuinationBranch(Network):
                                             unprotected_pido_pits = [p for p in pido_room.pits if p not in self.protected]
                                             this_conn = random.choice(unprotected_pido_pits)
                                             if self.verbose:
-                                                print(f'\t\tadded pido room from reserve area {area_name}: {rid}')
+                                                vprint(f'\t\tadded pido room from reserve area {area_name}: {rid}')
                                             break
                                 if this_conn is not None:
                                     break
@@ -2340,7 +2341,7 @@ class RuinationBranch(Network):
                         # Need a door-in, trap-out converter
                         dito = []
                         if self.verbose:
-                            print('\t\tlooking for available dito nodes:')
+                            vprint('\t\tlooking for available dito nodes:')
                         for node_id in available_nodes:
                             node = self.rooms.get_room(node_id)
                             unprotected_node_traps = [t for t in node.traps if t not in self.protected]
@@ -2349,7 +2350,7 @@ class RuinationBranch(Network):
                             if len(unprotected_node_traps) > 0 and len(unprotected_node_doors) > 0 and len(unprotected_node_traps) > len(unprotected_node_pits):
                                 dito.append(node_id)
                                 if self.verbose:
-                                    print('\t\t\t', node_id, ': ', node.count)
+                                    vprint('\t\t\t', node_id, ': ', node.count)
 
                         if len(dito) > 0:
                             dito_room_id = random.choice(dito)
@@ -2361,7 +2362,7 @@ class RuinationBranch(Network):
                         # Fallback: search reserve areas for a dito room
                         if len(dito) == 0 and reserve_areas is not None:
                             if self.verbose:
-                                print('\t\tno dito in network, checking reserve areas...')
+                                vprint('\t\tno dito in network, checking reserve areas...')
                             for area_name, area_rooms in reserve_areas:
                                 for rid in area_rooms:
                                     if rid in self.net.nodes:
@@ -2378,7 +2379,7 @@ class RuinationBranch(Network):
                                             unprotected_dito_doors = [d for d in dito_room.doors if d not in self.protected]
                                             this_conn = random.choice(unprotected_dito_doors)
                                             if self.verbose:
-                                                print(f'\t\tadded dito room from reserve area {area_name}: {rid}')
+                                                vprint(f'\t\tadded dito room from reserve area {area_name}: {rid}')
                                             break
                                 if this_conn is not None:
                                     break
@@ -2386,7 +2387,7 @@ class RuinationBranch(Network):
                     elif len(unprotected_room_doors) > 0 and len(upstream_doors) == 0 and len(upstream_pits) == 0:
                         # Upstream has nothing at all - need to add any room with a door
                         if self.verbose:
-                            print('\t\tupstream has no doors or pits, looking for a room with a door...')
+                            vprint('\t\tupstream has no doors or pits, looking for a room with a door...')
                         # Search network first
                         for node_id in available_nodes:
                             node = self.rooms.get_room(node_id)
@@ -2394,13 +2395,13 @@ class RuinationBranch(Network):
                             if len(unprotected_node_doors) > 0:
                                 this_conn = random.choice(unprotected_node_doors)
                                 if self.verbose:
-                                    print(f'\t\tfound door {this_conn} in network node {node_id}')
+                                    vprint(f'\t\tfound door {this_conn} in network node {node_id}')
                                 break
 
                         # Fallback: search reserve areas for any room with a door
                         if this_conn is None and reserve_areas is not None:
                             if self.verbose:
-                                print('\t\tno door-bearing room in network, checking reserve areas...')
+                                vprint('\t\tno door-bearing room in network, checking reserve areas...')
                             for area_name, area_rooms in reserve_areas:
                                 for rid in area_rooms:
                                     if rid in self.net.nodes:
@@ -2415,7 +2416,7 @@ class RuinationBranch(Network):
                                             unprotected_added_doors = [d for d in added_room.doors if d not in self.protected]
                                             this_conn = random.choice(unprotected_added_doors)
                                             if self.verbose:
-                                                print(f'\t\tadded room with door from reserve area {area_name}: {rid}')
+                                                vprint(f'\t\tadded room with door from reserve area {area_name}: {rid}')
                                             break
                                 if this_conn is not None:
                                     break
@@ -2431,7 +2432,7 @@ class RuinationBranch(Network):
                     )
 
                 if self.verbose:
-                    print('(2) connecting', this_exit, '-->', this_conn)
+                    vprint('(2) connecting', this_exit, '-->', this_conn)
                 self.connect(this_exit, this_conn)
 
                 # Update hub, upstream, downstream, delta
@@ -2446,13 +2447,13 @@ class RuinationBranch(Network):
                     exit_count = len(room.doors) + len(room.traps)
                     delta.append((entrance_count - exit_count, node))
                 if self.verbose:
-                    print('(2) delta values:', delta)
+                    vprint('(2) delta values:', delta)
                 delta.sort(key=_trap_priority)
 
             # If Fix B triggered a restart, skip remaining steps and go back to step 1
             if restart_finalization:
                 if self.verbose:
-                    print('(2) Fix B: restarting finalization after adding hub room')
+                    vprint('(2) Fix B: restarting finalization after adding hub room')
                 continue
 
             # Post-step-2 check: all downstream nodes should be merged into hub
@@ -2552,11 +2553,11 @@ class RuinationBranch(Network):
             while len(remaining_traps) > 0 and len(remaining_pits) > 0:
                 random.shuffle(remaining_pits)
                 if self.verbose:
-                    print('(3) remaining traps:', remaining_traps, '; pits: ', remaining_pits)
+                    vprint('(3) remaining traps:', remaining_traps, '; pits: ', remaining_pits)
                 this_exit = remaining_traps.pop()
                 this_conn = remaining_pits.pop()
                 if self.verbose:
-                    print('(3) connecting:', this_exit, '-->', this_conn)
+                    vprint('(3) connecting:', this_exit, '-->', this_conn)
                 self.connect(this_exit, this_conn)
                 # Re-collect from entire network - keys applied during connect() may unlock new traps
                 remaining_traps, remaining_pits = self.collect_network_traps_and_pits()
@@ -2566,7 +2567,7 @@ class RuinationBranch(Network):
             # so restart finalization from step 1 after adding.
             if len(remaining_traps) > 0 and reserve_areas is not None:
                 if self.verbose:
-                    print(f'(3) {len(remaining_traps)} traps remaining with no pits, checking reserve areas...')
+                    vprint(f'(3) {len(remaining_traps)} traps remaining with no pits, checking reserve areas...')
                 rescue_found = False
                 for area_name, area_rooms in reserve_areas:
                     for rid in list(area_rooms):
@@ -2579,7 +2580,7 @@ class RuinationBranch(Network):
                                 self.add_room(rid)
                                 area_rooms.remove(rid)
                                 if self.verbose:
-                                    print(f'(3) added room with pits from reserve area {area_name}: {rid}. '
+                                    vprint(f'(3) added room with pits from reserve area {area_name}: {rid}. '
                                           f'Restarting finalization.')
                                 rescue_found = True
                                 break
@@ -2606,7 +2607,7 @@ class RuinationBranch(Network):
             remaining_doors = [d for d in hub.doors if d not in self.protected]
             random.shuffle(remaining_doors)
             if self.verbose:
-                print('(4) remaining doors:', remaining_doors)
+                vprint('(4) remaining doors:', remaining_doors)
             terminus = self.rooms.get_room(self.terminus)
             if terminus is not None and len(remaining_doors) > 0:
                 # Terminus is still a separate room and we have doors to connect it
@@ -2616,16 +2617,16 @@ class RuinationBranch(Network):
                 unprotected_terminus_doors = [d for d in terminus.doors if d not in self.protected]
                 this_conn = unprotected_terminus_doors.pop() if unprotected_terminus_doors else terminus.doors.pop()
                 if self.verbose:
-                    print('(4) connecting terminus:', this_exit , '-->', this_conn)
+                    vprint('(4) connecting terminus:', this_exit , '-->', this_conn)
                 self.connect(this_exit, this_conn)
             elif terminus is not None and len(remaining_doors) == 0:
                 # Terminus exists but no hub doors available - add terminus to dead ends for step 6
                 if self.terminus not in self.dead_ends:
                     self.dead_ends.append(self.terminus)
                 if self.verbose:
-                    print('(4) no hub doors to connect terminus, deferring to step 6')
+                    vprint('(4) no hub doors to connect terminus, deferring to step 6')
             elif self.verbose:
-                print('(4) terminus already merged into hub, skipping')
+                vprint('(4) terminus already merged into hub, skipping')
 
             # (5) Count doors in hub.  Connect doors within hub until # doors <= # dead ends
             # Clean up dead ends first - use list() to avoid modifying during iteration
@@ -2641,18 +2642,18 @@ class RuinationBranch(Network):
             # (doors - dead_ends is odd), we'll end up with 1 orphan door.
             while len(remaining_doors) > len(self.dead_ends) and len(remaining_doors) >= 2:
                 if self.verbose:
-                    print('(5) doors in hub:', len(remaining_doors), '.  dead ends:', len(self.dead_ends))
+                    vprint('(5) doors in hub:', len(remaining_doors), '.  dead ends:', len(self.dead_ends))
                 this_exit = remaining_doors.pop()
                 this_conn = remaining_doors.pop()
                 if self.verbose:
-                    print('(5) connecting doors in hub:', this_exit, '-->', this_conn)
+                    vprint('(5) connecting doors in hub:', this_exit, '-->', this_conn)
                 self.connect(this_exit, this_conn)
 
             # (5b) Handle orphan door situation: we have more doors than dead ends but can't pair them
             if len(remaining_doors) > len(self.dead_ends):
                 orphan_count = len(remaining_doors) - len(self.dead_ends)
                 if self.verbose:
-                    print(f'(5b) orphan door situation: {orphan_count} excess door(s), searching for available rooms')
+                    vprint(f'(5b) orphan door situation: {orphan_count} excess door(s), searching for available rooms')
 
                 # Find rooms not yet in the network that can absorb the orphan doors
                 hub_id = [n for n in self.net.nodes if 'ruin_hub_' in str(n)][0]
@@ -2678,7 +2679,7 @@ class RuinationBranch(Network):
                             this_exit = remaining_doors.pop()
                             this_conn = random.choice(unprotected_room_doors)
                             if self.verbose:
-                                print(f'(5b) connecting orphan door {this_exit} --> room {room_id} door {this_conn}')
+                                vprint(f'(5b) connecting orphan door {this_exit} --> room {room_id} door {this_conn}')
                             self.connect(this_exit, this_conn)
                             # Add this room to dead_ends if it now has only one connection
                             if room_id not in self.dead_ends and len(room.doors) == 1:
@@ -2700,7 +2701,7 @@ class RuinationBranch(Network):
                                     this_exit = remaining_doors.pop()
                                     this_conn = random.choice(unprotected)
                                     if self.verbose:
-                                        print(f'(5b) fallback: connecting orphan {this_exit} --> {this_conn} in {node}')
+                                        vprint(f'(5b) fallback: connecting orphan {this_exit} --> {this_conn} in {node}')
                                     self.connect(this_exit, this_conn)
                                     found_connection = True
                                     break
@@ -2725,7 +2726,7 @@ class RuinationBranch(Network):
             # Skip entirely if no doors to connect
             if len(remaining_doors) == 0:
                 if self.verbose:
-                    print('(6) No remaining doors to connect, skipping step 6')
+                    vprint('(6) No remaining doors to connect, skipping step 6')
             else:
                 # Pre-check: we need enough dead ends for remaining doors
                 if len(remaining_doors) > len(self.dead_ends):
@@ -2759,8 +2760,8 @@ class RuinationBranch(Network):
                         dead_ends_without_keys.append(de_id)
 
                 if self.verbose:
-                    print('(6) remaining dead ends:', selected_dead_ends)
-                    print(f'(6) partitioned: {len(dead_ends_with_keys)} with keys, {len(dead_ends_without_keys)} without keys')
+                    vprint('(6) remaining dead ends:', selected_dead_ends)
+                    vprint(f'(6) partitioned: {len(dead_ends_with_keys)} with keys, {len(dead_ends_without_keys)} without keys')
 
                 # CRITICAL: The last dead end connected must NOT have a key.
                 # If all selected dead ends have keys, we need to find a keyless one from remaining pool.
@@ -2775,13 +2776,13 @@ class RuinationBranch(Network):
                             self.dead_ends.pop(i)
                             dead_ends_without_keys.append(candidate_id)
                             if self.verbose:
-                                print(f'(6) swapped key-bearing {swapped_out} for keyless {candidate_id}')
+                                vprint(f'(6) swapped key-bearing {swapped_out} for keyless {candidate_id}')
                             break
 
                 if len(dead_ends_without_keys) == 0 and len(dead_ends_with_keys) > 0:
                     # All dead ends have keys - this is risky but we must proceed
                     if self.verbose:
-                        print('(6) WARNING: All available dead ends have keys!')
+                        vprint('(6) WARNING: All available dead ends have keys!')
 
                 # Order: key-bearing first, keyless last (ensures last connection is safe)
                 ordered_dead_ends = dead_ends_with_keys + dead_ends_without_keys
@@ -2794,7 +2795,7 @@ class RuinationBranch(Network):
                     this_conn = unprotected_room_doors.pop() if unprotected_room_doors else room.doors.pop()
                     if self.verbose:
                         has_keys = room and len(room.keys) > 0
-                        print(f'(6) connecting dead ends: {this_exit} --> {this_conn} (has_keys={has_keys})')
+                        vprint(f'(6) connecting dead ends: {this_exit} --> {this_conn} (has_keys={has_keys})')
                     self.connect(this_exit, this_conn)
 
                     # Check if this connection unlocked TRULY NEW elements via key application.
@@ -2805,8 +2806,8 @@ class RuinationBranch(Network):
                     new_doors = [d for d in check_doors if d not in known_doors]
                     if len(new_traps) > 0 or len(new_doors) > 0:
                         if self.verbose:
-                            print(f'(6) Key unlocked new elements! Breaking early to preserve entrances.')
-                            print(f'    New traps: {new_traps}, New doors: {new_doors}')
+                            vprint(f'(6) Key unlocked new elements! Breaking early to preserve entrances.')
+                            vprint(f'    New traps: {new_traps}, New doors: {new_doors}')
                         # Return unused dead ends to the pool
                         self.dead_ends.extend(ordered_dead_ends)
                         break
@@ -2821,12 +2822,12 @@ class RuinationBranch(Network):
                 break  # Done - no new elements to process
 
             if self.verbose:
-                print(f'\nNew elements unlocked: {len(new_traps)} traps, {len(new_doors)} doors')
+                vprint(f'\nNew elements unlocked: {len(new_traps)} traps, {len(new_doors)} doors')
                 if new_traps:
-                    print(f'    traps: {new_traps}')
+                    vprint(f'    traps: {new_traps}')
                 if new_doors:
-                    print(f'    doors: {new_doors}')
-                print('Restarting finalization from step 1...\n')
+                    vprint(f'    doors: {new_doors}')
+                vprint('Restarting finalization from step 1...\n')
 
         if finalize_iteration >= max_finalize_iterations:
             # Collect remaining element info for diagnostics
@@ -2841,7 +2842,7 @@ class RuinationBranch(Network):
             )
 
         if self.verbose:
-            print('... closing branch complete!')
+            vprint('... closing branch complete!')
 
     def extend_branch_path(self):
         """Extend the branch by connecting an exit to an entrance.
@@ -2870,7 +2871,7 @@ class RuinationBranch(Network):
         if topology is None:
             # No hub yet - fall back to simple behavior
             if self.verbose:
-                print('\tNo hub found, using simple extension')
+                vprint('\tNo hub found, using simple extension')
             return self._extend_branch_path_simple()
 
         hub_id = topology['hub_id']
@@ -2885,10 +2886,10 @@ class RuinationBranch(Network):
         currently_connected = set(room_levels.keys())
 
         if self.verbose:
-            print(f'\t=== LOCATION-AWARE EXTENSION ===')
-            print(f'\tActive room: {self.active} (level {active_level})')
-            print(f'\tHub+Upstream: {hub_and_upstream}')
-            print(f'\tUpstream: {upstream}, Downstream: {downstream}')
+            vprint(f'\t=== LOCATION-AWARE EXTENSION ===')
+            vprint(f'\tActive room: {self.active} (level {active_level})')
+            vprint(f'\tHub+Upstream: {hub_and_upstream}')
+            vprint(f'\tUpstream: {upstream}, Downstream: {downstream}')
 
         # === STEP 1: Check for forced exits ===
         all_connected_rooms = [self.active] + list(downstream)
@@ -2903,7 +2904,7 @@ class RuinationBranch(Network):
             this_exit = forced_exits[0]
             this_conn = forced_connections[this_exit][0]
             if self.verbose:
-                print(f'\tForced exit: {this_exit} --> {this_conn}')
+                vprint(f'\tForced exit: {this_exit} --> {this_conn}')
             return this_exit, this_conn
 
         # === STEP 2: Collect exits from the active path ===
@@ -2943,7 +2944,7 @@ class RuinationBranch(Network):
             exit_room_id = list(deepest_rooms)[0] if deepest_rooms else self.active
 
         if self.verbose:
-            print(f'\tAvailable exits: {len(available_exits["doors"])} doors, {len(available_exits["traps"])} traps')
+            vprint(f'\tAvailable exits: {len(available_exits["doors"])} doors, {len(available_exits["traps"])} traps')
 
         # === STEP 3: Determine exit order based on location ===
         # ## Original logic:
@@ -2986,7 +2987,7 @@ class RuinationBranch(Network):
                     door_targets_exist = True
 
         if self.verbose:
-            print(f'\tTarget availability: pits={trap_targets_exist}, doors={door_targets_exist}')
+            vprint(f'\tTarget availability: pits={trap_targets_exist}, doors={door_targets_exist}')
 
         # Adjust order based on actual availability
         if exit_type_order[0] == 'traps' and not trap_targets_exist and door_targets_exist:
@@ -3011,7 +3012,7 @@ class RuinationBranch(Network):
                 all_exits.append((exit_id, exit_room.id))
 
             if self.verbose:
-                print(f'\t{exit_type}: {len(all_exits)} exits to evaluate')
+                vprint(f'\t{exit_type}: {len(all_exits)} exits to evaluate')
 
             # Shuffle and try each exit
             random.shuffle(all_exits)
@@ -3028,9 +3029,9 @@ class RuinationBranch(Network):
                     )
 
                 if self.verbose:
-                    print(f'\t\tExit {exit_id}: {len(valid_targets)} valid targets')
+                    vprint(f'\t\tExit {exit_id}: {len(valid_targets)} valid targets')
                     if False:
-                        print(valid_targets)
+                        vprint(valid_targets)
 
 
                 if len(valid_targets) > 0:
@@ -3038,7 +3039,7 @@ class RuinationBranch(Network):
                     if self.verbose:
                         conn_room = self.rooms.get_room_from_element(this_conn)
                         conn_room_id = conn_room.id if conn_room else 'unknown'
-                        print(f'\t\tSelected: {exit_id} --> {this_conn} (room {conn_room_id})')
+                        vprint(f'\t\tSelected: {exit_id} --> {this_conn} (room {conn_room_id})')
                     self.last_stuck_reason = StuckReason.NONE
                     return exit_id, this_conn
 
@@ -3046,7 +3047,7 @@ class RuinationBranch(Network):
         self._diagnose_stuck_reason(available_exits, topology)
 
         if self.verbose:
-            print(f'\tBranch extension failed. Reason: {self.last_stuck_reason}')
+            vprint(f'\tBranch extension failed. Reason: {self.last_stuck_reason}')
 
         return None, None
 
@@ -3142,12 +3143,12 @@ class RuinationBranch(Network):
         upstream = self.get_upstream_nodes(self.active)
         downstream = self.get_downstream_nodes(self.active)
         if self.verbose:
-            print('\tActive room: ', self.active, '.\n\tUpstream nodes: ', upstream,
+            vprint('\tActive room: ', self.active, '.\n\tUpstream nodes: ', upstream,
                   '\n\tDownstream nodes: ', downstream,
                   '\n\tAll entrances: ', all_entrances)
         hub_is_upstream = len([n for n in upstream if 'ruin_hub_' in str(n)]) > 0
         if hub_is_upstream and self.verbose:
-            print('\tHub is upstream!')
+            vprint('\tHub is upstream!')
         for node in upstream:
             room = self.rooms.get_room(node)
             all_entrances += list(room.doors) + list(room.pits)
@@ -3156,14 +3157,14 @@ class RuinationBranch(Network):
         dito_ok = len(
             all_entrances) >= 2  # a door-in, trap-out room effectively replaces a door (entrance) with a trap (not entrance), so an extra entrance is required
         if self.verbose and not allow_traps:
-            print('\ttraps not allowed!')
+            vprint('\ttraps not allowed!')
         elif self.verbose:
-            print('\ttraps allowed!')
+            vprint('\ttraps allowed!')
 
         # Look at unconnected hubs.
         currently_used = [self.active] + list(downstream) + list(upstream)
         if self.verbose:
-            print('\tCurrently used rooms:', currently_used)
+            vprint('\tCurrently used rooms:', currently_used)
         new_hub_door_conns = self.get_available_hub_connections(element_type=0, excluded=currently_used,
                                                                   dito_ok=dito_ok)
         new_hub_pit_conns = self.get_available_hub_connections(element_type=1, excluded=currently_used)
@@ -3173,7 +3174,7 @@ class RuinationBranch(Network):
             uppaths = self.get_upstream_paths(self.active)
             for path in uppaths:
                 if self.verbose:
-                    print('\tchecking upstream path:', path)
+                    vprint('\tchecking upstream path:', path)
                 path_door_count = 0
                 path_trap_count = 0
                 tracker = [False, False]
@@ -3185,23 +3186,23 @@ class RuinationBranch(Network):
                         # We've met the condition for trapdoor connections.  Add pits.
                         new_hub_pit_conns.update(node.pits)
                         if self.verbose and tracker[0] is False:
-                            print('\t\tTrapdoor condition met at', node_id)
+                            vprint('\t\tTrapdoor condition met at', node_id)
                             tracker[0] = True
                         if self.verbose:
-                            print('\t\tAdding', node_id, node.pits)
+                            vprint('\t\tAdding', node_id, node.pits)
                     if (path_door_count + path_trap_count) > 2:
                         # We've met the condition for door connections.  Add doors.
                         new_hub_door_conns.update(node.doors)
                         if self.verbose and tracker[1] is False:
-                            print('\t\tDoor condition met at', node_id)
+                            vprint('\t\tDoor condition met at', node_id)
                             tracker[1] = True
                         if self.verbose:
-                            print('\t\tAdding', node_id, node.doors)
+                            vprint('\t\tAdding', node_id, node.doors)
 
         if self.verbose:
-            print('\tCollected available hub connections:')
-            print('\t\tdoors:', new_hub_door_conns)
-            print('\t\tpits:', new_hub_pit_conns)
+            vprint('\tCollected available hub connections:')
+            vprint('\t\tdoors:', new_hub_door_conns)
+            vprint('\t\tpits:', new_hub_pit_conns)
 
         # Select which exits are permissable based on what is available.
         # WE HAVE TO BE CAREFUL to not fully map a branch before we run out of checks.
@@ -3224,8 +3225,8 @@ class RuinationBranch(Network):
                 all_exits += list(node.traps)
             available_connections[1] += new_hub_pit_conns
         if self.verbose:
-            print('\tCollected available active room exits:', len(all_exits))
-            print('\t\t', all_exits)
+            vprint('\tCollected available active room exits:', len(all_exits))
+            vprint('\t\t', all_exits)
 
         # Handle failure modes: no exits available
         legal_exits = True
@@ -3237,17 +3238,17 @@ class RuinationBranch(Network):
                 all_exits += list(active_room.doors)
                 available_connections[0] += check_door_cons
                 if self.verbose:
-                    print('\tInstead using rooms with checks (doors):', len(all_exits))
-                    print('\t\t', all_exits)
+                    vprint('\tInstead using rooms with checks (doors):', len(all_exits))
+                    vprint('\t\t', all_exits)
             elif len(check_pit_cons) > 0 and allow_traps:
                 all_exits += list(active_room.traps)
                 available_connections[1] += check_pit_cons
                 if self.verbose:
-                    print('\tInstead using rooms with checks (traps):', len(all_exits))
-                    print('\t\t', all_exits)
+                    vprint('\tInstead using rooms with checks (traps):', len(all_exits))
+                    vprint('\t\t', all_exits)
             else:
                 if self.verbose:
-                    print('No legal exits found on branch!')
+                    vprint('No legal exits found on branch!')
                 legal_exits = False
 
         # If any exits are forced, apply them
@@ -3257,19 +3258,19 @@ class RuinationBranch(Network):
                 this_exit = forced_exits.pop()
                 this_conn = forced_connections[this_exit][0]
                 if self.verbose:
-                    print('Found forced exit!', this_exit, '-->', this_conn)
+                    vprint('Found forced exit!', this_exit, '-->', this_conn)
             else:
                 this_exit = random.choice(all_exits)
                 this_type = active_room.element_type(this_exit)
                 if self.verbose:
-                    print('All allowed exits:', all_exits, '.  Choose: ', this_exit, '(type ', this_type, ')')
+                    vprint('All allowed exits:', all_exits, '.  Choose: ', this_exit, '(type ', this_type, ')')
                 # Reconstruct available connections for this exit?
 
                 if this_exit in available_connections[this_type]:
                     available_connections[this_type].remove(this_exit)
                 this_conn = random.choice(available_connections[this_type])
                 if self.verbose:
-                    print('Available connections:', available_connections[this_type], '. Choose: ', this_conn)
+                    vprint('Available connections:', available_connections[this_type], '. Choose: ', this_conn)
 
         else:
             this_exit = None
@@ -3282,7 +3283,7 @@ class RuinationBranch(Network):
         conn_room = self.rooms.get_room_from_element(this_conn)
         downstream = self.get_downstream_nodes(conn_room.id)
         if self.verbose:
-            print('Looking for reward in room', conn_room.id, '...')
+            vprint('Looking for reward in room', conn_room.id, '...')
         if conn_room.id in self.check_rooms:
             reward_room = conn_room.id
         elif len([n for n in downstream if n in self.check_rooms]) > 0:
@@ -3294,7 +3295,7 @@ class RuinationBranch(Network):
         if reward_room is not None:
             rewards = [(k, ROOM_REWARD[reward_room][k]) for k in ROOM_REWARD[reward_room].keys()]
             if self.verbose:
-                print('Found a reward! ', [(r[0], r[1].possible_types) for r in rewards], 'in room',
+                vprint('Found a reward! ', [(r[0], r[1].possible_types) for r in rewards], 'in room',
                       reward_room)
 
             # Remove check room from the list
@@ -3347,16 +3348,16 @@ class ruination_map():
         self.Requested[0] = random.randint(char_min, char_max)
         self.Requested[1] = random.randint(esper_min, esper_max)
         if self.verbose:
-            print('Requested: ', self.Requested[0], 'characters, ', self.Requested[1], 'espers')
+            vprint('Requested: ', self.Requested[0], 'characters, ', self.Requested[1], 'espers')
 
         # PRE-PLANNING PHASE: Determine which characters will be obtained and reserve areas
         self.planned_characters, self.reserve_characters, self.dead_checks_allowed = \
             self.pre_plan_character_acquisition()
 
         if self.verbose:
-            print('Pre-plan: Will obtain characters:', self.planned_characters)
-            print('Pre-plan: Reserve characters (for extra areas):', self.reserve_characters)
-            print('Pre-plan: Dead checks allowed:', self.dead_checks_allowed)
+            vprint('Pre-plan: Will obtain characters:', self.planned_characters)
+            vprint('Pre-plan: Reserve characters (for extra areas):', self.reserve_characters)
+            vprint('Pre-plan: Dead checks allowed:', self.dead_checks_allowed)
 
         # Check if any planned or starting party character has Blitz; if so, 50% chance to include Duncan's House
         self.include_duncan_house = False
@@ -3372,8 +3373,8 @@ class ruination_map():
                 self.duncan_house_character = all_blitz[0]
                 self.include_duncan_house = True
             if self.verbose:
-                print(f'Blitz characters: {blitz_char_names}')
-                print(f'Duncan\'s House: {"included" if self.include_duncan_house else "not included"}'
+                vprint(f'Blitz characters: {blitz_char_names}')
+                vprint(f'Duncan\'s House: {"included" if self.include_duncan_house else "not included"}'
                       + (f' (character: {self.duncan_house_character})' if self.include_duncan_house else ''))
 
         # Assemble initial areas from starting party + planned characters
@@ -3384,7 +3385,7 @@ class ruination_map():
         if self.include_duncan_house and self.duncan_house_character in self.PARTY:
             initial_areas.add('DuncanHouse')
         if self.verbose:
-            print('Areas used: ', initial_areas)
+            vprint('Areas used: ', initial_areas)
 
         # Create branches with starting areas
         hub_id = 'ruin_hub'
@@ -3410,7 +3411,7 @@ class ruination_map():
         # Distribute areas to the branches
         self.distribute_areas(initial_areas)
         if self.verbose:
-            print('Rewards available: ', self.RewardsAvailable)
+            vprint('Rewards available: ', self.RewardsAvailable)
 
         # Apply keys to branches
         for branch in self.branches:
@@ -3588,11 +3589,11 @@ class ruination_map():
                 result_map[1].append([d1, d2])
 
         if self.verbose:
-            print(f'Isolated maze internal connections: {len(result_map[0])} doors, {len(result_map[1])} traps')
+            vprint(f'Isolated maze internal connections: {len(result_map[0])} doors, {len(result_map[1])} traps')
             for d1, d2 in result_map[0]:
-                print(f'\tdoor: {d1} <-> {d2}')
+                vprint(f'\tdoor: {d1} <-> {d2}')
             for d1, d2 in result_map[1]:
-                print(f'\ttrap: {d1} -> {d2}')
+                vprint(f'\ttrap: {d1} -> {d2}')
 
         return result_map
 
@@ -3648,7 +3649,7 @@ class ruination_map():
                         total_esper_slots += 1
 
         if self.verbose:
-            print(f'Pre-plan: Planned areas have {total_checks} checks, '
+            vprint(f'Pre-plan: Planned areas have {total_checks} checks, '
                   f'{total_character_slots} character slots, {total_esper_slots} esper slots')
 
         # Check if we have enough esper slots after accounting for character slots
@@ -3660,7 +3661,7 @@ class ruination_map():
             new_areas = CHARACTER_AREAS.get(new_char, [])
 
             if self.verbose:
-                print(f'Pre-plan: Adding {new_char} to get more esper slots (areas: {new_areas})')
+                vprint(f'Pre-plan: Adding {new_char} to get more esper slots (areas: {new_areas})')
 
             # Count new slots from this character's areas
             for area_name in new_areas:
@@ -3746,7 +3747,7 @@ class ruination_map():
                     if partner in self.AreasUsed.keys():
                         branch_index = self.AreasUsed[partner]
                         if self.verbose:
-                            print('Forced same branch:', a, partner, branch_index)
+                            vprint('Forced same branch:', a, partner, branch_index)
                         return branch_index
                 return False
             return False
@@ -3773,7 +3774,7 @@ class ruination_map():
                             continue  # Can't assign to this branch
                         if area_analysis[area]['has_pido']:
                             if self.verbose:
-                                print(f'\tPriority: Assigning {area} to stuck branch {branch_id} (has PIDO rooms)')
+                                vprint(f'\tPriority: Assigning {area} to stuck branch {branch_id} (has PIDO rooms)')
                             branch_areas[branch_id].add(area)
                             self.AreasUsed[area] = branch_id
                             remaining_areas.remove(area)
@@ -3786,7 +3787,7 @@ class ruination_map():
                             continue  # Can't assign to this branch
                         if area_analysis[area]['has_hub']:
                             if self.verbose:
-                                print(f'\tPriority: Assigning {area} to stuck branch {branch_id} (has hub rooms)')
+                                vprint(f'\tPriority: Assigning {area} to stuck branch {branch_id} (has hub rooms)')
                             branch_areas[branch_id].add(area)
                             self.AreasUsed[area] = branch_id
                             remaining_areas.remove(area)
@@ -3819,7 +3820,7 @@ class ruination_map():
                 this_index = _check_forced_same_branch(area)
                 if this_index is False:
                     if self.verbose:
-                        print('\t\t# rooms on each branch: ', num_rooms)
+                        vprint('\t\t# rooms on each branch: ', num_rooms)
                     this_index = num_rooms.index(min(num_rooms))
                 branch_areas[this_index].add(area)
                 self.AreasUsed[area] = this_index
@@ -3836,9 +3837,9 @@ class ruination_map():
 
 
         if self.verbose:
-            print('Distributed areas:')
+            vprint('Distributed areas:')
             for i, b in enumerate(branch_areas):
-                print('\t', i, ': ', b)
+                vprint('\t', i, ': ', b)
 
         # Expand to list of rooms to add to each branch
         branch_rooms = [set(), set(), set()]
@@ -3872,9 +3873,9 @@ class ruination_map():
                             self.RewardsAvailable[1] += 1
 
         if self.verbose:
-            print('Checks available:')
+            vprint('Checks available:')
             for i, b in enumerate(self.branch_checks):
-                print('\t', i, ': ', b)
+                vprint('\t', i, ': ', b)
 
         # Add rooms to the branches (skip rooms that already exist in ANY branch)
         # Use all_rooms_added to include rooms that may have been merged into compound rooms
@@ -3904,7 +3905,7 @@ class ruination_map():
                             room = branch.rooms.get_room(room_id)
                             if room and _room_has_pido_potential(room):
                                 if self.verbose:
-                                    print(f'\tFound PIDO room {room_id} for stuck branch {i}')
+                                    vprint(f'\tFound PIDO room {room_id} for stuck branch {i}')
                                 should_unstick = True
                                 break
                     elif stuck_reason == StuckReason.NO_HUB:
@@ -3913,7 +3914,7 @@ class ruination_map():
                             room = branch.rooms.get_room(room_id)
                             if room and _room_has_hub_potential(room):
                                 if self.verbose:
-                                    print(f'\tFound hub room {room_id} for stuck branch {i}')
+                                    vprint(f'\tFound hub room {room_id} for stuck branch {i}')
                                 should_unstick = True
                                 break
                     else:
@@ -3923,7 +3924,7 @@ class ruination_map():
 
                     if should_unstick:
                         if self.verbose:
-                            print(f'\tUnsticking branch {i} - received helpful areas (was stuck: {stuck_reason})')
+                            vprint(f'\tUnsticking branch {i} - received helpful areas (was stuck: {stuck_reason})')
                         self.stuck_branches.pop(i, None)
 
     def apply_key(self, key):
@@ -3951,7 +3952,7 @@ class ruination_map():
                                     if reward_slot.possible_types & RewardType.ESPER:
                                         self.RewardsAvailable[1] += 1
                                     if self.verbose:
-                                        print(f'\tUnlocked reward {reward_name} added to branch {branch_id} checks')
+                                        vprint(f'\tUnlocked reward {reward_name} added to branch {branch_id} checks')
                                 break
 
     def get_non_veldt_gated_shops(self, characters):
@@ -3975,7 +3976,7 @@ class ruination_map():
         all_game_characters = set(self.PARTY) | set(self.planned_characters)
         if 'GAU' not in all_game_characters:
             if self.verbose:
-                print('Gau not in game characters, all accessible shops valid for dried meat')
+                vprint('Gau not in game characters, all accessible shops valid for dried meat')
             return self.accessible_shops[:]
 
         # Find which character was assigned to the Veldt reward
@@ -3989,13 +3990,13 @@ class ruination_map():
                     veldt_char_id = reward_slot.id
                     veldt_char_name = characters.DEFAULT_NAME[veldt_char_id]
                     if self.verbose:
-                        print(f'Veldt character: {veldt_char_name} (ID: {veldt_char_id})')
+                        vprint(f'Veldt character: {veldt_char_name} (ID: {veldt_char_id})')
                     break
 
         # If no character at Veldt (or Veldt not in map), all accessible shops are valid
         if veldt_char_id is None:
             if self.verbose:
-                print('No character at Veldt, all accessible shops valid for dried meat')
+                vprint('No character at Veldt, all accessible shops valid for dried meat')
             return self.accessible_shops[:]
 
         # Find all characters that depend on the Veldt character
@@ -4005,7 +4006,7 @@ class ruination_map():
             if veldt_char_id in characters.character_paths[char_id]:
                 veldt_gated_chars.add(char_id)
                 if self.verbose:
-                    print(f'  {characters.DEFAULT_NAME[char_id]} is gated by Veldt character')
+                    vprint(f'  {characters.DEFAULT_NAME[char_id]} is gated by Veldt character')
 
         # Collect areas unlocked by Veldt-gated characters
         veldt_gated_areas = set()
@@ -4015,7 +4016,7 @@ class ruination_map():
                 veldt_gated_areas.update(CHARACTER_AREAS[char_name])
 
         if self.verbose and veldt_gated_areas:
-            print(f'Veldt-gated areas: {veldt_gated_areas}')
+            vprint(f'Veldt-gated areas: {veldt_gated_areas}')
 
         # Collect shop IDs in Veldt-gated areas
         veldt_gated_shops = set()
@@ -4028,9 +4029,9 @@ class ruination_map():
                           if shop_id not in veldt_gated_shops]
 
         if self.verbose:
-            print(f'Accessible shops: {len(self.accessible_shops)}')
-            print(f'Veldt-gated shops: {list(veldt_gated_shops)}')
-            print(f'Non-Veldt-gated shops: {len(non_veldt_shops)} - {non_veldt_shops}')
+            vprint(f'Accessible shops: {len(self.accessible_shops)}')
+            vprint(f'Veldt-gated shops: {list(veldt_gated_shops)}')
+            vprint(f'Non-Veldt-gated shops: {len(non_veldt_shops)} - {non_veldt_shops}')
 
         # Warn if no non-Veldt-gated shops exist when Gau is in the game
         if not non_veldt_shops and 'GAU' in all_game_characters:
@@ -4155,7 +4156,7 @@ class ruination_map():
                 forced_connections.pop(fc)
 
         if self.verbose:
-            print('Generating map with characters...')
+            vprint('Generating map with characters...')
 
         ### This approach fails if a branch has only dead ends on it.  For example: a branch could initially get just
         # 'Gau Father House', 'Floating Continent', both of which are dead ends.
@@ -4170,7 +4171,7 @@ class ruination_map():
             # Pick a branch that is not all dead ends.  Requires at least one true hub room
             branch_is_viable = [b.has_a_hub() for b in self.branches]
             if self.verbose:
-                print('Branch viability:', branch_is_viable, 'Stuck:', self.stuck_branches)
+                vprint('Branch viability:', branch_is_viable, 'Stuck:', self.stuck_branches)
             viable_branches = [b for b in range(3) if len(self.branch_checks[b]) > 0 and branch_is_viable[b] and b not in self.stuck_branches]
             if len(viable_branches) > 0:
                 branch_id = random.choice(viable_branches)
@@ -4198,7 +4199,7 @@ class ruination_map():
                     # Use the best reserve area (most hub potential)
                     new_area, new_rooms = reserve_areas[0]
                     if self.verbose:
-                        print(f'Adding reserve area {new_area} ({len(new_rooms)} rooms) to unstick branch {branch_id}')
+                        vprint(f'Adding reserve area {new_area} ({len(new_rooms)} rooms) to unstick branch {branch_id}')
 
                     # Mark area as used
                     self.AreasUsed[new_area] = branch_id
@@ -4217,7 +4218,7 @@ class ruination_map():
                     for room in new_rooms:
                         if room in existing_rooms:
                             if self.verbose:
-                                print(f'\tSkipping room {room} - already exists')
+                                vprint(f'\tSkipping room {room} - already exists')
                             continue
                         branch.add_room(room)
 
@@ -4228,7 +4229,7 @@ class ruination_map():
                                 if reward_id not in self.branch_checks[branch_id]:
                                     self.branch_checks[branch_id].append(reward_id)
                                     if self.verbose:
-                                        print(f'\tAdded new check: {reward_id}')
+                                        vprint(f'\tAdded new check: {reward_id}')
 
                     self.stuck_branches.pop(branch_id, None)  # Give it another chance
 
@@ -4237,13 +4238,13 @@ class ruination_map():
                     hub_id = [n for n in branch.net.nodes if 'ruin_hub_' in str(n)][0]
                     branch.active = hub_id
                     if self.verbose:
-                        print(f'\tReset branch {branch_id} active room to hub: {hub_id}')
+                        vprint(f'\tReset branch {branch_id} active room to hub: {hub_id}')
 
                 elif len(CHARACTER_AREAS.get('EXTRA', [])) > 0:
                     # Fallback to EXTRA areas if no reserve areas left
                     new_area = CHARACTER_AREAS['EXTRA'].pop()
                     if self.verbose:
-                        print('Adding extra area', new_area, 'to unstick branch', branch_id)
+                        vprint('Adding extra area', new_area, 'to unstick branch', branch_id)
                     # Skip rooms that already exist (use all_rooms_added to catch merged rooms)
                     existing_rooms = set()
                     for b in self.branches:
@@ -4251,7 +4252,7 @@ class ruination_map():
                     for room in RUIN_ROOM_SETS[new_area]:
                         if room in existing_rooms:
                             if self.verbose:
-                                print(f'\tSkipping room {room} - already exists')
+                                vprint(f'\tSkipping room {room} - already exists')
                             continue
                         branch.add_room(room)
                     self.stuck_branches.pop(branch_id, None)
@@ -4260,7 +4261,7 @@ class ruination_map():
                     hub_id = [n for n in branch.net.nodes if 'ruin_hub_' in str(n)][0]
                     branch.active = hub_id
                     if self.verbose:
-                        print(f'\tReset branch {branch_id} active room to hub: {hub_id}')
+                        vprint(f'\tReset branch {branch_id} active room to hub: {hub_id}')
 
                 else:
                     # Collect diagnostic information
@@ -4277,24 +4278,24 @@ class ruination_map():
                 if de not in branch.net.nodes:
                     branch.dead_ends.remove(de)
                     if self.verbose:
-                        print('\ttrimmed dead end ', de)
+                        vprint('\ttrimmed dead end ', de)
 
             if self.verbose:
-                print('Working on branch', branch_id, '(', self.branch_checks[branch_id], ')')
-                print('status: terminus', branch.terminus)
-                print('status: check rooms', branch.check_rooms)
-                print('status: dead ends', branch.dead_ends)
+                vprint('Working on branch', branch_id, '(', self.branch_checks[branch_id], ')')
+                vprint('status: terminus', branch.terminus)
+                vprint('status: check rooms', branch.check_rooms)
+                vprint('status: dead ends', branch.dead_ends)
 
             # Force any forced connections before starting
             if self.verbose:
-                print('Forcing connections...')
+                vprint('Forcing connections...')
             branch.ForceConnections(forced_connections)
 
             # Forcing connections can update the name of the active branch
             if branch.active not in branch.net.nodes:
                 new_active = [n_id for n_id in branch.net.nodes if branch.active in str(n_id)]
                 if self.verbose:
-                    print('updating active room id: ', branch.active, '-->', new_active[0])
+                    vprint('updating active room id: ', branch.active, '-->', new_active[0])
                 branch.active = new_active[0]
 
             # Apply any keys we have found in other branches
@@ -4315,12 +4316,12 @@ class ruination_map():
                     retries += 1
                     if retries >= max_retries_per_branch:
                         if self.verbose:
-                            print(f'Branch {branch_id} is stuck after {retries} retries. Reason: {branch.last_stuck_reason}')
+                            vprint(f'Branch {branch_id} is stuck after {retries} retries. Reason: {branch.last_stuck_reason}')
                         self.stuck_branches[branch_id] = branch.last_stuck_reason
                         break
                     else:
                         if self.verbose:
-                            print(f'Branch {branch_id} failed to extend, retry {retries}/{max_retries_per_branch}')
+                            vprint(f'Branch {branch_id} failed to extend, retry {retries}/{max_retries_per_branch}')
                         continue  # Try again with different random choices
 
                 # Check if a reward was found
@@ -4339,7 +4340,7 @@ class ruination_map():
                                 self.LockedRewards[locker].append(
                                     (branch_id, [r]))  # (branch_id, [check_name, check_data])
                                 if self.verbose:
-                                    print('\t\treward is locked by', locker, '. Saving for later.')
+                                    vprint('\t\treward is locked by', locker, '. Saving for later.')
                             else:
                                 # We have the locking character, so reward is accessed.
                                 accessible_rewards.append(r)
@@ -4351,7 +4352,7 @@ class ruination_map():
 
                 # Actually connect them.  This also moves the active room to the new room.
                 if self.verbose:
-                    print('Making connection: ', this_exit, '-->', this_conn)
+                    vprint('Making connection: ', this_exit, '-->', this_conn)
                 branch.connect(this_exit, this_conn)
 
             ### Process reward & restart loop - only if we actually found a reward
@@ -4359,7 +4360,7 @@ class ruination_map():
                 self.process_rewards(accessible_rewards, characters, espers, items, branch_id=branch_id, exclude_chars=non_planned_chars)
             elif branch_id in self.stuck_branches:
                 if self.verbose:
-                    print(f'Skipping reward processing for stuck branch {branch_id}')
+                    vprint(f'Skipping reward processing for stuck branch {branch_id}')
 
             # If not in the hub room, return to the hub room?
 
@@ -4405,7 +4406,7 @@ class ruination_map():
                         if shop_id not in self.accessible_shops:
                             self.accessible_shops.append(shop_id)
                 if self.verbose:
-                    print(f'Added ALL area {area_name} to branch {target_branch_id}')
+                    vprint(f'Added ALL area {area_name} to branch {target_branch_id}')
 
         # After satisfying conditions, fully connect map
         reserve_areas = self.get_reserve_area_rooms()
@@ -4526,30 +4527,30 @@ class ruination_map():
             reward_name = reward[0]  # reward_name = slot.event.name()
             slot = reward[1]
             if self.verbose:
-                print('Processing reward: ', reward_name)
+                vprint('Processing reward: ', reward_name)
 
             remaining_chars_needed = len(self.planned_characters) - self.RewardsObtained[0]
             if remaining_chars_needed >= 1 and self.RewardsAvailable[0] == 1 and (slot.possible_types & RewardType.CHARACTER):
                 # This must be a character.
                 if self.verbose:
-                    print('\tmust be a character')
+                    vprint('\tmust be a character')
                 # Use characters.get_random_available with exclude parameter
                 slot.id = characters.get_random_available(exclude=exclude_chars)
                 slot.type = RewardType.CHARACTER
                 if self.verbose:
-                    print('\tgot ', characters.get_name(slot.id), '!')
+                    vprint('\tgot ', characters.get_name(slot.id), '!')
             else:
                 # Just choose from among available types
                 if self.verbose:
-                    print('\tchoosing from...', slot.possible_types)
+                    vprint('\tchoosing from...', slot.possible_types)
                 slot.id, slot.type = self._choose_reward_with_exclusion(slot.possible_types, characters, espers, items, exclude_chars)
                 if self.verbose:
                     if slot.type is RewardType.CHARACTER:
-                        print('\tgot', characters.get_name(slot.id), '!')
+                        vprint('\tgot', characters.get_name(slot.id), '!')
                     elif slot.type is RewardType.ESPER:
-                        print('\tgot', espers.get_name(slot.id), '!')
+                        vprint('\tgot', espers.get_name(slot.id), '!')
                     elif slot.type is RewardType.ITEM:
-                        print('\tgot', items.get_name(slot.id), '!')
+                        vprint('\tgot', items.get_name(slot.id), '!')
 
             # Update RewardsObtained
             if slot.type is RewardType.CHARACTER:
@@ -4561,7 +4562,7 @@ class ruination_map():
                 if self.verbose and slot.event.character_gate() is not None:
                     unlocker_name = characters.DEFAULT_NAME[slot.event.character_gate()]
                     new_char_name = characters.DEFAULT_NAME[slot.id]
-                    print(f'\tSet character path: {new_char_name} depends on {unlocker_name}')
+                    vprint(f'\tSet character path: {new_char_name} depends on {unlocker_name}')
 
                 # If a character, add new areas to the map
                 new_char = characters.DEFAULT_NAME[slot.id]
@@ -4571,7 +4572,7 @@ class ruination_map():
                 if self.include_duncan_house and new_char == self.duncan_house_character:
                     new_areas.append('DuncanHouse')
                     if self.verbose:
-                        print(f'\tAdding DuncanHouse to {new_char}\'s areas (Blitz character)')
+                        vprint(f'\tAdding DuncanHouse to {new_char}\'s areas (Blitz character)')
                 self.distribute_areas(new_areas, method='shortest')
 
             elif slot.type is RewardType.ESPER:
@@ -4584,8 +4585,8 @@ class ruination_map():
                 self.RewardsAvailable[1] -= 1
 
             if self.verbose:
-                print('\tUpdated Rewards Obtained: ', self.RewardsObtained[0], 'Characters, ', self.RewardsObtained[1], 'Espers')
-                print('\tUpdated Rewards Available: ', self.RewardsAvailable[0], 'Characters, ',
+                vprint('\tUpdated Rewards Obtained: ', self.RewardsObtained[0], 'Characters, ', self.RewardsObtained[1], 'Espers')
+                vprint('\tUpdated Rewards Available: ', self.RewardsAvailable[0], 'Characters, ',
                       self.RewardsAvailable[1],
                       'Espers')
 
@@ -4608,9 +4609,9 @@ class ruination_map():
             # Update branch_checks
             self.branch_checks[branch_id].remove(reward_name)
             if self.verbose:
-                print('\tUpdated branch checks available:')
+                vprint('\tUpdated branch checks available:')
                 for i, bc in enumerate(self.branch_checks):
-                    print('\t', i, ': ', bc)
+                    vprint('\t', i, ': ', bc)
 
             # If a new character unlocks a reward we already found, apply it.
             if slot.type is RewardType.CHARACTER:
@@ -4622,7 +4623,7 @@ class ruination_map():
                         unlocked_rewards = v[1]
                         for new_reward in unlocked_rewards:
                             if self.verbose:
-                                print('\tUnlocked an available reward!', new_reward[0], 'on branch', v[0])
+                                vprint('\tUnlocked an available reward!', new_reward[0], 'on branch', v[0])
                             # Add to branch_checks so it can be properly removed during processing
                             self.branch_checks[v[0]].append(new_reward[0])
                             # First add this to rewards available (since it was never done)

--- a/log/__init__.py
+++ b/log/__init__.py
@@ -1,5 +1,6 @@
 import logging, os
 from log.format import *
+from log import verbose as verbose_log
 
 import args
 name, ext = os.path.splitext(args.output_file)
@@ -9,6 +10,15 @@ if args.stdout_log:
     logging.basicConfig(stream = sys.stdout, filemode = 'w', level = logging.INFO, format = "%(message)s")
 else:
     logging.basicConfig(filename = log_file, filemode = 'w', level = logging.INFO, format = "%(message)s")
+
+# Configure verbose diagnostics destinations.
+# -debug routes verbose output to stdout (legacy behaviour).
+# -debug-verbose routes verbose output to a temp file that is appended
+# to the spoiler log file at the end of the compile.
+verbose_log.init(
+    to_stdout = bool(getattr(args, "debug", False)),
+    to_file = bool(getattr(args, "debug_verbose", False)),
+)
 
 hash = ', '.join([entry.name for entry in args.sprite_hash])
 import time

--- a/log/verbose.py
+++ b/log/verbose.py
@@ -1,0 +1,110 @@
+"""Verbose diagnostic logging for ruin mode.
+
+Provides vprint() for diagnostic output produced by data.doors, data.maps,
+data.transitions, data.walks, data.warps, and event.ruination.
+
+Destinations are chosen by init():
+    -debug           -> stdout (legacy behaviour)
+    -debug-verbose   -> temporary file that is appended to the spoiler log
+                        at the end of the compile
+
+Both flags may be combined. When neither is set, vprint() is a no-op.
+"""
+
+import os
+import tempfile
+
+_to_stdout = False
+_to_file = False
+_temp_file = None
+_temp_path = None
+
+
+def init(to_stdout=False, to_file=False):
+    """Configure verbose destinations. Safe to call more than once."""
+    global _to_stdout, _to_file, _temp_file, _temp_path
+    _to_stdout = bool(to_stdout)
+    _to_file = bool(to_file)
+    if _to_file and _temp_file is None:
+        _temp_file = tempfile.NamedTemporaryFile(
+            mode="w",
+            delete=False,
+            suffix=".txt",
+            prefix="wc_debug_verbose_",
+            encoding="utf-8",
+        )
+        _temp_path = _temp_file.name
+
+
+def is_enabled():
+    return _to_stdout or _to_file
+
+
+def vprint(*args, **kwargs):
+    """Print verbose diagnostic output to the configured destinations."""
+    if _to_stdout:
+        print(*args, **kwargs)
+    if _to_file and _temp_file is not None:
+        kwargs.pop("file", None)
+        print(*args, file=_temp_file, **kwargs)
+        _temp_file.flush()
+
+
+def get_temp_path():
+    return _temp_path
+
+
+def finalize_and_append_to_log():
+    """Close the temp file and append its contents to the spoiler log.
+
+    Called at the end of the compile. No-op if the temp file was never
+    created (e.g. -debug-verbose was not set).
+
+    Writes via the ``logging`` module so the output is routed to whichever
+    destination the log handler is configured with (file or stdout).
+    """
+    global _temp_file, _temp_path
+    if _temp_file is None:
+        return
+
+    try:
+        _temp_file.flush()
+    except Exception:
+        pass
+    try:
+        _temp_file.close()
+    except Exception:
+        pass
+
+    path = _temp_path
+    _temp_file = None
+    _temp_path = None
+
+    if path is None:
+        return
+
+    content = ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError:
+        content = ""
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    if not content:
+        return
+
+    import logging
+    header = " Debug Verbose Diagnostics "
+    logging.info("")
+    logging.info("-" * 120)
+    logging.info(header.center(120, "-"))
+    logging.info("-" * 120)
+    # logging.info writes one record per call but embeds whatever string we
+    # hand it - including newlines - so a single call with the full temp
+    # file contents preserves the original line breaks.
+    logging.info(content.rstrip("\n"))

--- a/wc.py
+++ b/wc.py
@@ -26,6 +26,11 @@ def main():
     data.write()
     memory.write()
 
+    # Append -debug-verbose diagnostics (if any) to the spoiler log. No-op
+    # unless -debug-verbose is set on the command line.
+    from log import verbose as verbose_log
+    verbose_log.finalize_and_append_to_log()
+
     #if data.maps.doors.verbose:
     #    from memory.space import Space
     #    print(Space.heaps)


### PR DESCRIPTION
Playtesters using remote seed-generation tools couldn't previously share -debug diagnostic output, since -debug writes it to stdout and also turns on unrelated gameplay changes (weak enemies, etc.).

Introduces -debug-verbose / -dv: enables the verbose diagnostic prints in data.doors, data.maps, data.transitions, data.walks, data.warps, data.map_events, event.ruination, and event.events without any of the other -debug side effects. Verbose output is written to a temp file and appended to the spoiler log at the end of the compile (the flag also implies -sl).

- New log/verbose.py module: init/vprint/finalize_and_append_to_log.
- wc.py finalizes and appends at the end of main().
- verbose prints inside `if ... self.verbose ...:` blocks across the affected modules are routed through vprint. When neither -debug nor -debug-verbose is set, vprint is a no-op.
- Transitions, Events, and Doors now honour either flag for their self.verbose attribute.

https://claude.ai/code/session_013hg3pLKo4xppgujJqs95ce