### PR TITLE
Fix Sell menu desync after opening Buy menu with -sli flag

### DIFF
--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -806,10 +806,15 @@ These addresses are verified unused during shop menu operations (Bank C3 B4xx-BA
 | $37 | 1 byte | Temp: item ID during compact_init |
 | $38 | 1 byte | Temp: original slot index in hook_buy_setup |
 | $40-$41 | 2 bytes | Temp: shop_num×8 in hook_buy_setup (16-bit) |
+| $42 | 1 byte | SLOT_TEMP_DP: temp for slot index or pack size |
+| $60-$61 | 2 bytes | UNIT_PRICE_SAVE_DP: saved unit price (for restore after pack-price inflation) |
+| $62-$63 | 2 bytes | PACK_TEMP_DP: 16-bit scratch for pack table computation / multiply results |
 | $78-$7F | 8 bytes | compact_items buffer (available items packed to top, rest $FF) |
 | $B8-$BF | 8 bytes | slot_map buffer (display position → original shop slot index) |
 
-**Verified safe DP addresses (from in-game testing):** $25, $30, $36, $37, $38, $40, $41, $42, $49, $4A, $60, $61, $62, $63, $66, $78-$7F, $B8-$BF.
+**Verified safe DP addresses (from in-game testing):** $25, $30, $36, $37, $38, $40, $41, $42, $60, $61, $62, $63, $66, $78-$7F, $B8-$BF.
+
+**⚠️ DO NOT USE $49 or $4A as scratch:** Despite being in the previous "verified safe" list, these are actually the sell menu's persistent state — `$49` is the sell menu's "Top BG1 write row" (read at C3/83F7 → `$E6`) and `$4A` is its "List scroll position" (read at C3/83F7 and C3/BBF8). The shop init at C3/B47C only zeros `$4A` once on shop entry and never re-initializes either between submenu transitions. Clobbering them inside the buy hooks causes a desync on first Sell-menu open after Buy: items draw at wrong BG1 rows (cursor appears at visual row 0 while `$4B` points to a different inventory slot). Pressing L/R fixes it because the scroll handler at C3/1F64 recomputes both registers. Earlier versions of the `-sli` hooks used `$49-$4A` as PACK_TEMP_DP and hit this bug; the fix is to use `$62-$63` instead.
 
 ### Item Compaction System
 

--- a/menus/buy.py
+++ b/menus/buy.py
@@ -18,7 +18,13 @@ class BuyMenu:
 
     # Free DP bytes used as temporaries for price inflation / pack lookup
     SLOT_TEMP_DP       = 0x42   # 1 byte: temp for slot index or pack size
-    PACK_TEMP_DP       = 0x49   # 2 bytes ($49-$4A): temp for pack table computation
+    # NOTE: $49-$4A are NOT safe for scratch — $49 is the sell menu's "top BG1
+    # write row" and $4A is its "list scroll position" (used by C3/83F7 and
+    # C3/BBE0).  Clobbering them during buy caused a desync on first Sell open
+    # (items drawn at wrong BG1 rows or from wrong inventory slot).  Use $62-$63
+    # instead: the Bank C3 disassembly confirms they're unused in the shop menu
+    # code range B4xx-BFxx.
+    PACK_TEMP_DP       = 0x62   # 2 bytes ($62-$63): temp for pack table computation
     UNIT_PRICE_SAVE_DP = 0x60   # 2 bytes ($60-$61): saved unit price for restore
 
     def __init__(self):
@@ -88,7 +94,7 @@ class BuyMenu:
             asm.ASL(),
             asm.ASL(),
             asm.ASL(),                                   # *8
-            asm.STA(self.PACK_TEMP_DP, asm.DIR),         # $49-$4A
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),         # $62-$63
             asm.LDA(self.SLOT_TEMP_DP, asm.DIR),
             asm.AND(0x00ff, asm.IMM16),
             asm.CLC(),
@@ -278,9 +284,9 @@ class BuyMenu:
             asm.NOP(),
             asm.NOP(),
             asm.LDA(0x4216, asm.ABS),           # R1_low
-            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $49
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $62
             asm.LDA(0x4217, asm.ABS),           # R1_high (carry)
-            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $4A
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $63
 
             # Step 2: price_high * pack
             asm.LDA(self.UNIT_PRICE_SAVE_DP + 1, asm.DIR),  # $61 = price high byte
@@ -295,15 +301,15 @@ class BuyMenu:
             # Combine: final_high = R2_low + R1_high
             asm.CLC(),
             asm.LDA(0x4216, asm.ABS),           # R2_low
-            asm.ADC(self.PACK_TEMP_DP + 1, asm.DIR),  # + R1_high ($4A)
+            asm.ADC(self.PACK_TEMP_DP + 1, asm.DIR),  # + R1_high ($63)
             asm.BCS("CAP_PRICE"),               # overflow → cap
-            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),  # $4A = final high byte
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),  # $63 = final high byte
             asm.LDA(0x4217, asm.ABS),           # R2_high
             asm.BNE("CAP_PRICE"),               # >0 → cap
 
-            # Store inflated price: $49 = low, $4A = high
+            # Store inflated price: $62 = low, $63 = high
             asm.REP(0x20),
-            asm.LDA(self.PACK_TEMP_DP, asm.DIR),  # 16-bit result from $49-$4A
+            asm.LDA(self.PACK_TEMP_DP, asm.DIR),  # 16-bit result from $62-$63
             asm.STA(0x7e9f09, asm.LNG_X),
             asm.SEP(0x20),
             asm.BRA("DONE"),
@@ -479,9 +485,9 @@ class BuyMenu:
             asm.STA(0x4203, asm.ABS),           # trigger multiply
             asm.NOP(), asm.NOP(), asm.NOP(), asm.NOP(),
             asm.LDA(0x4216, asm.ABS),           # R1_low
-            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $49
+            asm.STA(self.PACK_TEMP_DP, asm.DIR),            # $62
             asm.LDA(0x4217, asm.ABS),           # R1_high
-            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $4A
+            asm.STA(self.PACK_TEMP_DP + 1, asm.DIR),        # $63
 
             # Step 2: $F4 (high byte) * pack
             asm.LDA(0xf4, asm.DIR),


### PR DESCRIPTION
The BuyMenu's PACK_TEMP_DP was set to $49, which aliases the sell menu's persistent "Top BG1 write row" ($49) and "List scroll position" ($4A) direct-page state (per Bank C3 disassembly at C3/83F7 and C3/BBE0). Buy-menu multiply operations clobbered both, so on first Sell-menu open after visiting Buy, items were drawn at the wrong BG1 rows while the cursor sprite remained at its default pixel position, producing the reported desync between the cursor and the selected item. Pressing L/R masked it because the scroll handler at C3/1F64 re-initializes both addresses.

Move PACK_TEMP_DP to $62-$63, which the disassembly confirms is unused throughout the shop code range (B4xx-BFxx). ARCHIVE.md is updated to drop $49/$4A from the "verified safe" list and to warn future work away from them.

https://claude.ai/code/session_01MSrXMxrGL3NbBPYqCbSFKi