### PR TITLE
Fix Zozo WoR->Cliff connection firing 'Return to Parent Map' on re-entry

### DIFF
--- a/event/mt_zozo.py
+++ b/event/mt_zozo.py
@@ -299,6 +299,11 @@ class MtZozo(Event):
         # replaces has_entrance_event;
         # to be used in event_exit_info.entrance_door_patch()
 
+        # When the branch condition misses we must fall through to the caller's LoadMap, not
+        # Return() early. Returning early short-circuits shared_map_exit_event's FadeLoadMap
+        # (used by logical WoR exits like 5224), leaving the underlying long exit to fire its
+        # vanilla dest_map=0x1ff (return to parent map).
+
         CYAN = 2
 
         # CC/3FA7: C0    If ($1E80($0D2) [$1E9A, bit 2] is set), branch to $CA5EB3 (simply returns)
@@ -306,11 +311,9 @@ class MtZozo(Event):
             src = [
                 field.BranchIfAll([event_bit.FINISHED_MT_ZOZO, False,
                                    event_bit.character_recruited(CYAN), True], 0xc3fad),
-                field.Return()
             ]
         else:
             src = [
                 field.BranchIfEventBitClear(event_bit.FINISHED_MT_ZOZO, 0xc3fad),
-                field.Return()
             ]
         return src


### PR DESCRIPTION
The entrance_door_patch for door 1204 (Mt Zozo Cyan's Cliff) ended with field.Return(), which short-circuited shared_map_exit_event's prepend path:

    wor_src = edp + [FadeLoadMap(0xb5, 15, 20), Return()]

On the first entry FINISHED_MT_ZOZO is clear, the Branch fires and the vanilla recruit event at CC/3FAD runs (which loads the cliff itself). On subsequent entries the Branch misses, the trailing Return() ends the event script without loading any map, and the underlying long exit (index 95 at Zozo, shared by 1224/5224) then fires its vanilla dest_map=0x1ff - sending the player back to the parent world map instead of Cyan's Cliff.

Dropping the trailing Return() lets execution fall through to the caller's FadeLoadMap on the miss path. The create_exit_event path is unaffected: its src is built as src[:-1] + edp + src[-1:], so the terminal Return() still ends the script and allows the (correctly randomized) door to fire.

https://claude.ai/code/session_01JDytgY7SosZuSdUvGR9FcS