### PR TITLE
Fix softlock in BedHealCharacter MP/no-op path

### DIFF
--- a/instruction/field/custom.py
+++ b/instruction/field/custom.py
@@ -240,6 +240,9 @@ class BedHealCharacter(_Instruction):
             asm.BRA("DONE"),
 
             "HEAL_MP",
+            # Reached from BCS above while still in A16. Vanilla MAX_MP
+            # routine expects A8, so switch back before the JSR.
+            asm.A8(),
             asm.JSR(MAX_MP_INTO_1E, asm.ABS),   # $1E = max MP, returns A8
             asm.A16(),
             asm.LDA(CURRENT_MP, asm.ABS_Y),


### PR DESCRIPTION
BCS from the HP comparison jumps to HEAL_MP while the CPU is still in A16 (set earlier for 16-bit HP arithmetic). The vanilla MAX_MP routine at \$0AFA3 expects A8, so calling it in A16 corrupts the stack/flow and softlocks on a black screen.

Switch back to A8 before the JSR, then A16 for the arithmetic.

https://claude.ai/code/session_01JWynTgbmp3FYuvrBuHZRvN