### PR TITLE
Extract party interaction pointer-set as shared Bank.CA subroutine

### DIFF
--- a/event/esper_world.py
+++ b/event/esper_world.py
@@ -72,11 +72,20 @@ class EsperWorld(Event):
         self.maps.add_event(self.map_gate_cave, save_event)
 
     def cleanup_esper_world(self):
-        # Turn off the entrance events for these rooms
+        # Replace the vanilla entrance events for these rooms. In ruination mode,
+        # point them at the shared party-interaction-pointer subroutine so NPC talk
+        # events are re-bound whenever the player enters (needed after loading a
+        # save, since field RAM pointers aren't preserved). Otherwise, point at
+        # a bare Return.
         RETURN_ADDR = 0x5eb3
-        self.maps.maps[self.map_outside]["entrance_event_address"] = RETURN_ADDR
-        self.maps.maps[self.map_gate_cave]["entrance_event_address"] = RETURN_ADDR
-        self.maps.maps[self.map_interiors]["entrance_event_address"] = RETURN_ADDR
+        if self.args.ruination_mode:
+            from event.ruination import SET_PARTY_INTERACTION_POINTERS
+            entrance_addr = SET_PARTY_INTERACTION_POINTERS - EVENT_CODE_START
+        else:
+            entrance_addr = RETURN_ADDR
+        self.maps.maps[self.map_outside]["entrance_event_address"] = entrance_addr
+        self.maps.maps[self.map_gate_cave]["entrance_event_address"] = entrance_addr
+        self.maps.maps[self.map_interiors]["entrance_event_address"] = entrance_addr
 
         # Delete event tile in gate cave: 0xaa78f -- 0xaa7f4
         self.maps.delete_event(self.map_gate_cave, 56, 49)

--- a/event/narshe_wob.py
+++ b/event/narshe_wob.py
@@ -687,13 +687,13 @@ class NarsheWOB(Event):
         # Also restore away-party character availability when a party returns
         # Set all characters' talk-event pointers so party interaction works
         # after loading a saved game (field RAM pointers aren't preserved in saves).
-        from event.ruination import set_party_interaction_pointers_src
+        from event.ruination import SET_PARTY_INTERACTION_POINTERS
         entrance_src = [
             field.TintBackground(field.Tint.NIGHT),
             field.RestoreActivePartyAvailable(),  # idempotent: no-op if party isn't away
+            field.Call(SET_PARTY_INTERACTION_POINTERS),
+            field.Return(),
         ]
-        entrance_src += set_party_interaction_pointers_src()
-        entrance_src += [field.Return()]
         space = Write(Bank.CA, entrance_src, "Narshe school ruination entrance event")
         self.maps.set_entrance_event(school_map_id, space.start_address - EVENT_CODE_START)
 

--- a/event/ruination.py
+++ b/event/ruination.py
@@ -6038,6 +6038,12 @@ PARTY_INTERACT_CHOICE_DIALOG = 1320
 # NarsheWob/Start to emit ChangeNPCEventAddress instructions.
 PARTY_INTERACTION_SCRIPT_ADDRS = {}
 
+# ROM address of the shared "set all party interaction NPC pointers" subroutine.
+# Populated by create_party_interaction_scripts() (runs before the event mod loop).
+# Callers import this lazily (inside a method) and invoke it via field.Call, or
+# assign it as a map's entrance_event_address (after subtracting EVENT_CODE_START).
+SET_PARTY_INTERACTION_POINTERS = None
+
 
 def create_party_interaction_scripts(dialogs):
     """Create per-character event scripts for party interaction in ruination mode.
@@ -6113,29 +6119,37 @@ def create_party_interaction_scripts(dialogs):
     # CA/3F13-CA/3F82 (112 bytes, 8 per character).
     Free(0xa3f13, 0xa3f82)
 
+    # Write the shared subroutine that repoints every recruited character's
+    # NPC talk event to its party-interaction script. Runs after the per-character
+    # scripts above so PARTY_INTERACTION_SCRIPT_ADDRS is fully populated. Must
+    # happen before the event.mod() loop so callers (NarsheWob, EsperWorld)
+    # can read SET_PARTY_INTERACTION_POINTERS.
+    _write_set_party_interaction_pointers_subroutine()
 
-def set_party_interaction_pointers_src(char_ids=None):
-    """Return a list of ChangeNPCEventAddress instructions for the given characters.
 
-    Args:
-        char_ids: Iterable of character IDs, or None for all 14 characters.
+def _write_set_party_interaction_pointers_subroutine():
+    """Write the 'set all party interaction NPC pointers' subroutine to Bank.CA once.
 
-    Returns:
-        List of field instructions to include in an event script.
+    For each of the 14 characters, emits:
+        if character_recruited(c): ChangeNPCEventAddress(c, PARTY_INTERACTION_SCRIPT_ADDRS[c])
+    followed by a Return so the subroutine can be invoked via field.Call or used
+    as a map entrance_event. Stores the full SNES address in the module-level
+    SET_PARTY_INTERACTION_POINTERS.
     """
     from constants.entities import CHARACTER_COUNT
-    if char_ids is None:
-        char_ids = range(CHARACTER_COUNT)
+    global SET_PARTY_INTERACTION_POINTERS
+
     src = []
-    for char_id in char_ids:
+    for char_id in range(CHARACTER_COUNT):
         addr = PARTY_INTERACTION_SCRIPT_ADDRS[char_id]
-        char_src = [
+        src += [
             field.BranchIfEventBitClear(event_bit.character_recruited(char_id), f"SKIP_{char_id}"),
             field.ChangeNPCEventAddress(char_id, addr),
             f"SKIP_{char_id}",
         ]
-        src.append(char_src)
-    return src
+    src.append(field.Return())
+    space = Write(Bank.CA, src, "set party interaction pointers subroutine")
+    SET_PARTY_INTERACTION_POINTERS = space.start_address
 
 
 def disable_chocobo_stables(rom, dialogs, args):


### PR DESCRIPTION
Write the per-character NPC pointer-rebinding code once at the end of create_party_interaction_scripts and expose its address as SET_PARTY_INTERACTION_POINTERS. NarsheWob's school entrance event now invokes it via field.Call instead of inlining the full body, and EsperWorld.cleanup_esper_world uses it as the entrance event for the three repurposed esper-world maps.