### PR TITLE
Ruin ferry: gate South Figaro <-> Nikeah on rooms actually mapped


### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -6524,12 +6524,16 @@ def fix_ferry_connections(rom, dialogs, ruin_map, args):
     Args:
         rom: The ROM object to modify
         dialogs: The Dialogs object to update dialog text
-        ruin_map: The ruination_map object containing AreasUsed
+        ruin_map: The ruination_map object
         args: Command line arguments (for debug flag)
     """
-    # Check if both South Figaro and Nikeah are mapped
-    south_figaro_mapped = 'SouthFigaro' in ruin_map.AreasUsed
-    nikeah_mapped = 'Nikeah' in ruin_map.AreasUsed
+    # Use the rooms actually placed in each branch (not ruin_map.AreasUsed),
+    # because distribution can tag an area with a branch whose rooms already
+    # lived elsewhere — leaving the ferry enabled when South Figaro or Nikeah
+    # has no reachable rooms on the map.
+    actual_areas_used = ruin_map.compute_actual_areas_used()
+    south_figaro_mapped = 'SouthFigaro' in actual_areas_used
+    nikeah_mapped = 'Nikeah' in actual_areas_used
 
     if south_figaro_mapped and nikeah_mapped:
         if args.debug:


### PR DESCRIPTION

ruin_map.AreasUsed records which branch an area was *distributed* to,
but distribution can tag a branch whose rooms already lived elsewhere
(or whose rooms are unreachable post-finalize). That left the ferry
enabled when one of the towns had no connected rooms on the map,
letting players board it and exit to the world map from an unmapped
Nikeah.

Switch the ferry check to ruin_map.compute_actual_areas_used(), the
same data structure the Narshe school clue fix uses to confirm an
area's rooms are reachable in some branch.

https://claude.ai/code/session_01FgmThAwKE1KDLKqPNh4mhN