### PR TITLE
Refresh hub_id before step-6 warp room classification

### DIFF
--- a/event/ruination.py
+++ b/event/ruination.py
@@ -3052,6 +3052,10 @@ class RuinationBranch(Network):
             # one remaining_door, just like a normal step-6 dead-end connection.
             # This restores the >=2 connected-warp invariant without risking
             # inescapable downstream nodes earlier in finalization.
+            # Step 4's terminus connect (and any prior step) may have merged the
+            # hub into a new compound node, so re-fetch hub_id before passing it
+            # into the digraph-aware classifier.
+            hub_id = [n for n in self.net.nodes if 'ruin_hub_' in str(n)][0]
             connected_warps, unconnected_warps = self._classify_branch_warp_rooms(hub_id)
             while (len(connected_warps) < 2
                    and len(remaining_doors) > 0
@@ -3068,6 +3072,8 @@ class RuinationBranch(Network):
                 # Avoid double-counting if the warp was tracked as a dead end.
                 if warp_id in self.dead_ends:
                     self.dead_ends.remove(warp_id)
+                # connect() may have merged the warp into the hub; refresh.
+                hub_id = [n for n in self.net.nodes if 'ruin_hub_' in str(n)][0]
                 connected_warps, unconnected_warps = self._classify_branch_warp_rooms(hub_id)
 
             # Skip entirely if no doors to connect


### PR DESCRIPTION
Step 4's terminus connect() merges the terminus node into the hub, producing a new compound node id. The local hub_id captured at line 2927 is now stale, so passing it to _classify_branch_warp_rooms() at step 6.0 made get_upstream_nodes() blow up with "node ... is not in the digraph".

Re-fetch hub_id immediately before the step-6.0 classifier call, and again after each connect() inside the rescue loop (those connects can also merge the warp into the hub).