### PR TITLE
Wire Network.verbose to central -debug/-dv flag

### DIFF
--- a/data/walks.py
+++ b/data/walks.py
@@ -3,7 +3,7 @@ import networkx as nx
 import random
 from copy import deepcopy
 import numpy as np
-from log.verbose import vprint
+from log.verbose import vprint, is_enabled as _verbose_enabled
 
 
 class NetworkRecursionError(Exception):
@@ -16,7 +16,16 @@ class NetworkRecursionError(Exception):
 
 
 class Network:
-    verbose = False
+    @property
+    def verbose(self):
+        return _verbose_enabled()
+
+    @verbose.setter
+    def verbose(self, value):
+        # Verbose output is controlled centrally by -debug / -debug-verbose.
+        # The setter is kept for backwards compatibility with callers that
+        # still flip self.verbose; assignments are ignored.
+        pass
 
     def __init__(self, rooms):
         self.original_room_ids = list(rooms)  # Store original IDs


### PR DESCRIPTION
Network had verbose=False as a class attribute, so the ~76 'if self.verbose:' guards in walks.py suppressed the diagnostic vprints from connect_network() even when the user passed -debug or -debug-verbose. Only the few unguarded vprints in doors.py (e.g. 'Initial Count', 'starting room...') were visible, so door-randomization timeouts were impossible to diagnose.

Make Network.verbose a property that returns log.verbose.is_enabled(), matching the pattern Doors already uses. The setter is kept as a no-op so existing callers (e.g. ruination.py's maze_net.verbose=True) don't break.