### PR TITLE
Tint Mag.Order overlay text with the live font palette

### DIFF
--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -287,8 +287,16 @@ Two-pass overlay:
       pixels, not the full ring.  Letter outlines coincide with the
       procedural shadow and are unaffected.
    3. Bright-pixel stamp: any source pixel with `max channel > 70`
-      copies its own colour, overpainting any shadow that lands on an
-      adjacent glyph cell.
+      stamps the live font palette scaled by source brightness
+      (`font_8bit · md[i] / 255` per channel), overpainting any shadow
+      that lands on an adjacent glyph cell.  The crops were captured
+      under W1's default (white) font, so the source is grayscale and
+      the multiply collapses to a flat font-colour tint at the source's
+      brightness — bright letter strokes get the full font colour, the
+      dim bullet outlines stay proportionally dimmer.  Previously the
+      stamp just copied `md[i]` unchanged, which left the Mag.Order
+      text frozen at white even when the rest of the menu's text
+      recoloured.
 
 ## Text-highlight masks
 

--- a/web/main.js
+++ b/web/main.js
@@ -491,10 +491,18 @@ function drawMagOrderText() {
   //       on the Attack row, whose outline is below TEXT_THRESHOLD and
   //       would otherwise be skipped (the procedural shadow only covers
   //       the down-right side of bright pixels, not a full ring).
-  //    c) Bright source pixel itself, which overpaints any shadow that
-  //       lands on an adjacent glyph cell.
+  //    c) Bright source pixel itself, tinted with the live font palette
+  //       so the overlay text matches whatever colour the rest of the
+  //       menu's text uses.  The crops were captured under W1's default
+  //       (white) font so source[i] is grayscale — scaling by the user's
+  //       font colour preserves the per-pixel brightness ramp (the dim
+  //       bullet outlines stay dimmer than the bright letter strokes).
+  //       Pure black survives as black since md[i] · anything = 0.
   const TEXT_THRESHOLD = 70;
   const DARK_THRESHOLD = 10;
+  const fr = state.font[0] * 255 / 31;
+  const fg = state.font[1] * 255 / 31;
+  const fb = state.font[2] * 255 / 31;
   const region = ctx.getImageData(x0, y0, w, h);
   const rd = region.data, md = img.data;
   const stride = w * 4;
@@ -521,9 +529,10 @@ function drawMagOrderText() {
   for (let i = 0; i < rd.length; i += 4) {
     const mx = Math.max(md[i], md[i + 1], md[i + 2]);
     if (mx > TEXT_THRESHOLD) {
-      rd[i    ] = md[i    ];
-      rd[i + 1] = md[i + 1];
-      rd[i + 2] = md[i + 2];
+      const t = mx / 255;
+      rd[i    ] = Math.round(fr * t);
+      rd[i + 1] = Math.round(fg * t);
+      rd[i + 2] = Math.round(fb * t);
     }
   }
   ctx.putImageData(region, x0, y0);


### PR DESCRIPTION
drawMagOrderText() was stamping the source crop's bright pixels unchanged (md[i] verbatim), which froze the A•/B•/C• rows at white even when the rest of the menu's text was recolouring with the user's font palette — visible on Page B as a white block under "Mag.Order" that ignored a non-white font selection.

The crops were captured under W1's default (white) font, so the source is grayscale (only 255 and 115 above the brightness gate). Multiplying each bright pixel by font_8bit/255 collapses to a flat font-colour tint at the source's per-pixel brightness — bright letter strokes get the full font colour, the dim bullet outlines stay proportionally dimmer.  Pure black survives as black (anything · 0 = 0) so the Attack row's filled-ball outline still reads as a hard ring, and the procedural drop shadow is still painted pure black before this pass so it doesn't tint with the font either.