### PR TITLE
Add config-JSON upload to restore the configurator state

### DIFF
--- a/web/designer.js
+++ b/web/designer.js
@@ -533,6 +533,99 @@
       '`ff6_config.py -i rom.smc --config ff6config.json`', false);
   });
 
+  // ---- upload (restore from previously downloaded JSON) -------------
+
+  document.getElementById('ds-config-upload').addEventListener('change', async (e) => {
+    const input = e.target;
+    const f = input.files && input.files[0];
+    if (!f) return;
+    try {
+      const text = await f.text();
+      let cfg;
+      try { cfg = JSON.parse(text); }
+      catch (err) { throw new Error('not valid JSON: ' + err.message); }
+      if (cfg.version !== 1)
+        throw new Error(`unsupported config version: ${cfg.version}`);
+
+      // Decode graphics first so we can fail before mutating state if any
+      // blob is malformed.  Each entry: { n, pixels, palette }.
+      const decoded = [];
+      const graphics = cfg.graphics || {};
+      for (const [nStr, b64] of Object.entries(graphics)) {
+        const n = parseInt(nStr, 10);
+        if (!(n >= 1 && n <= 8))
+          throw new Error(`bad window number ${JSON.stringify(nStr)}`);
+        if (typeof b64 !== 'string')
+          throw new Error(`window ${n} blob is not a string`);
+        let bin;
+        try { bin = atob(b64); }
+        catch (err) { throw new Error(`window ${n}: bad base64`); }
+        if (bin.length !== BLOB_BYTES)
+          throw new Error(`window ${n} blob is ${bin.length} bytes, ` +
+                          `expected ${BLOB_BYTES}`);
+        const blob = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) blob[i] = bin.charCodeAt(i);
+        const pixels  = enc.decodeSheet(blob.subarray(0, enc.SHEET_BYTES));
+        const palette = enc.decodePalette(blob.subarray(enc.SHEET_BYTES));
+        decoded.push({ n, pixels, palette });
+      }
+      decoded.sort((a, b) => a.n - b.n);
+
+      // Push the flagstring through the configurator -- this resets every
+      // toggle, font color, and window palette to either the embedded value
+      // or its default (so a flag that's absent snaps back instead of
+      // inheriting the previous session's value).
+      await ff6c.applyFlagString(cfg.flags || '');
+
+      // Replace customGraphics from scratch.  The flagstring already wrote
+      // each window's palette into SHARED.windows, but the graphics blob
+      // carries the palette too and we treat that as authoritative for the
+      // saved design (in practice they always match, since the download
+      // side reads them from the same source).
+      ds.customGraphics = {};
+      ds.lastTexUpload = null;
+      for (const { n, pixels, palette } of decoded) {
+        ff6c.setPaletteBulk(n, palette.slice(1, 8));
+        ds.customGraphics[n] = {
+          pixels: new Uint8Array(pixels),
+          borderId: '__current__',
+          lastTexUpload: null,
+        };
+      }
+
+      // Snap the designer's view to the first customized window so the
+      // user lands on something visible instead of an untouched window.
+      const target = decoded.length ? decoded[0].n : ds.currentWindow;
+      ds.currentWindow = target;
+      const sel = document.getElementById('window-style');
+      if (sel && parseInt(sel.value, 10) !== target) {
+        sel.value = String(target);
+        sel.dispatchEvent(new Event('change'));
+      }
+      const cur = ds.customGraphics[target];
+      if (cur && cur.pixels) {
+        ds.pixels = new Uint8Array(cur.pixels);
+        ds.borderId = cur.borderId;
+      } else {
+        const v = window.VANILLA_GRAPHICS && window.VANILLA_GRAPHICS[target];
+        ds.pixels = v ? new Uint8Array(v.pixels) : new Uint8Array(SHEET_W * SHEET_H);
+        ds.borderId = '__current__';
+      }
+      updateWindowBanner();
+      render();
+      ff6c.refresh && ff6c.refresh();
+
+      const n = decoded.length;
+      setStatus(`loaded ${f.name} (${n} custom window` +
+                (n === 1 ? '' : 's') + ')', false);
+    } catch (err) {
+      setStatus('config upload failed: ' + err.message, true);
+    } finally {
+      // Reset so picking the same file again still fires "change".
+      input.value = '';
+    }
+  });
+
   // ---- status line ---------------------------------------------------
 
   const statusEl = document.getElementById('ds-status');

--- a/web/encoder.js
+++ b/web/encoder.js
@@ -61,6 +61,53 @@
     return out;
   }
 
+  // Inverse of encodeTile4bpp: read 32 bytes back into 64 pixel indices.
+  function decodeTile4bpp(bytes32) {
+    const out = new Uint8Array(64);
+    for (let r = 0; r < 8; r++) {
+      const bp0 = bytes32[2 * r];
+      const bp1 = bytes32[2 * r + 1];
+      const bp2 = bytes32[16 + 2 * r];
+      const bp3 = bytes32[17 + 2 * r];
+      for (let x = 0; x < 8; x++) {
+        const bit = 7 - x;
+        out[r * 8 + x] = ((bp0 >> bit) & 1) |
+                         (((bp1 >> bit) & 1) << 1) |
+                         (((bp2 >> bit) & 1) << 2) |
+                         (((bp3 >> bit) & 1) << 3);
+      }
+    }
+    return out;
+  }
+
+  function decodeSheet(bytes) {
+    const pixels = new Uint8Array(SHEET_W * SHEET_H);
+    let off = 0;
+    for (let ty = 0; ty < TILES_H; ty++) {
+      for (let tx = 0; tx < TILES_W; tx++) {
+        const tile = decodeTile4bpp(bytes.subarray(off, off + TILE_BYTES));
+        for (let y = 0; y < 8; y++) {
+          for (let x = 0; x < 8; x++) {
+            pixels[(ty * 8 + y) * SHEET_W + (tx * 8 + x)] = tile[y * 8 + x];
+          }
+        }
+        off += TILE_BYTES;
+      }
+    }
+    return pixels;
+  }
+
+  // Read the first 8 palette entries (slots 0..7) from a 32-byte BGR15 block.
+  // Vanilla filler in slots 8..15 is ignored.
+  function decodePalette(bytes32) {
+    const out = [];
+    for (let i = 0; i < 8; i++) {
+      const v = bytes32[2 * i] | (bytes32[2 * i + 1] << 8);
+      out.push([v & 0x1F, (v >> 5) & 0x1F, (v >> 10) & 0x1F]);
+    }
+    return out;
+  }
+
   // palette: 8 entries (R,G,B 0..31 each).  Pad to 16 with vanilla filler.
   function encodePalette(palette) {
     const out = new Uint8Array(PAL_BYTES);
@@ -151,6 +198,7 @@
 
   return {
     encodeTile4bpp, encodeSheet, encodePalette,
+    decodeTile4bpp, decodeSheet, decodePalette,
     medianCut, sortByLuminosity, lumin,
     bgr5_to_rgb8, rgb8_to_bgr5,
     SHEET_W, SHEET_H, SHEET_BYTES, PAL_BYTES, BLOB_BYTES,

--- a/web/index.html
+++ b/web/index.html
@@ -144,6 +144,11 @@
           <legend>Output</legend>
           <button id="ds-revert" type="button" disabled>Revert this window to default</button>
           <button id="ds-download" type="button">Download configuration (.json)</button>
+          <label class="ds-upload-config" for="ds-config-upload">
+            Load configuration (.json):
+          </label>
+          <input type="file" id="ds-config-upload" accept="application/json,.json"
+                 title="Restore the configurator from a previously downloaded ff6config.json">
           <div id="ds-status" class="ds-status"></div>
         </fieldset>
       </div>

--- a/web/main.js
+++ b/web/main.js
@@ -1529,6 +1529,112 @@ document.getElementById('copy-flags').addEventListener('click', async () => {
 // handler would cause N renders + N flag-string rebuilds for one user
 // gesture; this batches them into one.
 
+// ---------------- flagstring parser (for config-JSON upload) ----------
+//
+// Inverse of buildFlagString(): split a flagstring into tokens, then
+// map each `-flag value` pair into ``state``.  Reset to defaults first
+// so flags that are *absent* from the upload snap back rather than
+// inheriting the previous session's value.
+//
+// The Python CLI accepts the same arguments and is the source of truth
+// for the format; mirror its parsers for the small handful of value
+// shapes we have to read (rgb triples, window palettes).
+
+function shlexSplit(s) {
+  // Minimal POSIX-ish split: handles single and double quotes and
+  // backslash escapes.  buildFlagString only quotes -wN values, so we
+  // don't need anything fancier.
+  const out = [];
+  let cur = '', has = false, sq = false, dq = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (!sq && !dq && /\s/.test(c)) {
+      if (has) { out.push(cur); cur = ''; has = false; }
+      continue;
+    }
+    if (!sq && c === '"') { dq = !dq; has = true; continue; }
+    if (!dq && c === "'") { sq = !sq; has = true; continue; }
+    if (!sq && c === '\\' && i + 1 < s.length) {
+      cur += s[++i]; has = true; continue;
+    }
+    cur += c; has = true;
+  }
+  if (has) out.push(cur);
+  return out;
+}
+
+function parseRgbTriple(s) {
+  const parts = s.split(',');
+  if (parts.length !== 3) throw new Error(`bad rgb triple ${JSON.stringify(s)}`);
+  const out = parts.map(p => parseInt(p, 10));
+  for (const v of out) {
+    if (!Number.isInteger(v) || v < 0 || v > 31)
+      throw new Error(`rgb component out of 0..31 in ${JSON.stringify(s)}`);
+  }
+  return out;
+}
+
+const FLAG_MAP = {
+  '-b':   { key: 'BatMode'  },
+  '-bs':  { key: 'BatSpeed',   int: true },
+  '-ms':  { key: 'MsgSpeed',   int: true },
+  '-com': { key: 'Command'  },
+  '-g':   { key: 'Gauge'    },
+  '-s':   { key: 'Sound'    },
+  '-c':   { key: 'Cursor'   },
+  '-r':   { key: 'Reequip'  },
+  '-so':  { key: 'SpellOrder', int: true },
+  '-w':   { key: 'Wallpaper',  int: true },
+};
+
+function applyFlagString(flags) {
+  // Hard reset to defaults so anything missing from the flagstring is
+  // restored, not left over from a previous session.
+  Object.assign(state, structuredClone(TOGGLE_DEFAULTS));
+  state.font = [...FONT_DEFAULT];
+  state.windows = structuredClone(WINDOW_DEFAULTS);
+  state.editing = { kind: 'font' };
+  state.cursor = 0;
+
+  const toks = shlexSplit(flags || '');
+  for (let i = 0; i < toks.length; i++) {
+    const flag = toks[i];
+    const val  = toks[i + 1];
+    if (val === undefined) throw new Error(`flag ${flag} missing value`);
+    if (FLAG_MAP[flag]) {
+      const spec = FLAG_MAP[flag];
+      state[spec.key] = spec.int ? parseInt(val, 10) : val;
+    } else if (flag === '-f') {
+      state.font = parseRgbTriple(val);
+    } else if (/^-w[1-8]$/.test(flag)) {
+      const n = parseInt(flag.slice(2), 10);
+      for (const entry of val.split(';')) {
+        if (!entry) continue;
+        const eq = entry.indexOf('=');
+        if (eq < 0) throw new Error(`bad palette entry ${JSON.stringify(entry)}`);
+        const slot = parseInt(entry.slice(0, eq), 10);
+        if (!(slot >= 1 && slot <= 7))
+          throw new Error(`slot ${slot} out of range in ${flag} ${JSON.stringify(val)}`);
+        state.windows[n][slot - 1] = parseRgbTriple(entry.slice(eq + 1));
+      }
+    } else {
+      throw new Error(`unknown flag ${JSON.stringify(flag)}`);
+    }
+    i++;
+  }
+
+  // Sync side panels + canvas to the freshly-loaded state.
+  document.getElementById('window-style').value = String(state.WindowStyle);
+  document.getElementById('wallpaper').value    = String(state.Wallpaper);
+  return loadWindowAssets(state.WindowStyle).then(() => {
+    updateTabUI();
+    syncSidePanel();
+    render();
+    updateFlagString();
+    notifyStateChange({ kind: 'config-load' });
+  });
+}
+
 if (typeof window !== 'undefined') {
   window.ff6c.setPaletteBulk = function (windowN, palette7) {
     for (let i = 0; i < 7; i++) {
@@ -1548,6 +1654,7 @@ if (typeof window !== 'undefined') {
   window.ff6c.refresh = function () {
     render();
   };
+  window.ff6c.applyFlagString = applyFlagString;
 }
 
 // ---------------- boot ----------------


### PR DESCRIPTION
The designer's existing 'Download configuration (.json)' produces a self-contained bundle (flagstring + per-window graphics blobs).  Users who came back later to tweak a saved design had no way to load that bundle back into the web UI, so they had to either rebuild from scratch or apply through the CLI and live without further iteration.

Adds a 'Load configuration (.json)' file input next to the download button.  Reading the same JSON it writes:

  - The flagstring is parsed back into the configurator state (toggles, font color, every window's palette), resetting anything absent to its default so a fresh upload doesn't inherit the previous session.
  - Each graphics blob is decoded (4bpp sheet + BGR15 palette) and stored in the designer's customGraphics, with the embedded palette pushed through setPaletteBulk to keep the two state copies in sync.
  - The designer view snaps to the lowest-numbered customized window so the user lands on something visible.

Bad uploads (wrong version, malformed base64, wrong blob size, bad rgb component) show an error in the existing ds-status line without touching state.