### PR TITLE
Add player-2 controller assignments (Config4 / $1D4F)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ palettes, font color, etc.).
 Originally built for FF6 [Worlds Collide][wc] ROMs.  Config1 (battle
 mode, battle speed, command set, message speed) lives at a fixed
 address that works on any vanilla-layout FF6 ROM.  Config2 (controller
-2, spell order, …) and Config3 (gauge, cursor, sound, re-equip,
-wallpaper) require a small **trampoline** to be installed in the ROM
-first; if you don't have a WC-patched ROM, run
+2, spell order, …), Config3 (gauge, cursor, sound, re-equip, wallpaper)
+and Config4 (`$1D4F` — which battle characters player 2 controls when
+the controller is set to `multiple`) require a small **trampoline** to
+be installed in the ROM first; if you don't have a WC-patched ROM, run
 [`install_trampoline.py`](#trampoline) first.
 
 [wc]: https://www.ff6wc.com
@@ -42,6 +43,8 @@ hard-coded default).
 | Cursor       | `-c`, `--cursor`             | `reset` \| `memory`                            |
 | Re-equip     | `-r`, `--reequip`            | `optimum` \| `empty`                           |
 | Spell order  | `-so`, `--spell-order`       | integer `1`..`6`                               |
+| Controller   | `-ctrl`, `--controller`      | `single` \| `multiple`                         |
+| Player 2     | `-p2`, `--player2`           | subset of `1,2,3,4` (e.g. `13`); needs `multiple` |
 | Font color   | `-f`, `--font`               | `R,G,B` (each component `0`..`31`)             |
 | Wallpaper    | `-w`, `--wallpaper`          | integer `1`..`8`                               |
 | Window 1..8  | `-w1`..`-w8`, `--window1`..  | `slot=R,G,B;slot=R,G,B;...` (slot `1`..`7`)    |
@@ -79,14 +82,17 @@ writes `ff6wc_test_config.smc` with the chosen defaults baked in.
 ## Trampoline
 
 In a vanilla FF6 ROM, the boot code at file offset `0x0370C2`
-(SNES `$C3/70C2`) zeroes the Config2 and Config3 RAM bytes (`$1D54`
-and `$1D4E`) inline with two `STZ ABS` instructions — there's no
-settable default to override.
+(SNES `$C3/70C2`) zeroes the Config2, Config3 and Config4 RAM bytes
+(`$1D54`, `$1D4E` and `$1D4F`) inline with three consecutive `STZ ABS`
+instructions — there's no settable default to override.
 
-Worlds Collide replaces those two `STZ`s with `JSR` calls to a pair of
-6-byte subroutines elsewhere in bank `$C3`.  Each subroutine is
-`LDA #$NN; STA $1Dxx; RTS`; `ff6_config` works by patching the `NN`
-immediate inside each one.
+`install_trampoline.py` replaces those three `STZ`s with `JSR` calls to
+a trio of 6-byte subroutines elsewhere in bank `$C3`.  Each subroutine
+is `LDA #$NN; STA $1Dxx; RTS`; `ff6_config` works by patching the `NN`
+immediate inside each one.  The third subroutine (`$1D4F`) is what backs
+the `-p2`/`--player2` controller assignments; if a ROM only has the
+older two-`JSR` trampoline, a non-zero `-p2` is rejected with a hint to
+re-run the installer (a `single`/all-player-1 default still works).
 
 If your ROM was patched by WC, the trampoline is already there
 (installed in `settings/__init__.py`).  For a vanilla ROM, run:
@@ -96,7 +102,7 @@ python3 install_trampoline.py -i ff6_vanilla.smc -o ff6_ready.smc
 python3 ff6_config.py -i ff6_ready.smc --bat-speed 6 ...
 ```
 
-The installer writes 12 bytes at file offset `0x03F091`
+The installer writes 18 bytes at file offset `0x03F091`
 (SNES `$C3/F091`) by default, a region the published FF6 ROM map lists
 as unused (3951 bytes starting at `$C3/F091`).  The boot code at
 `$C3/70C2` is in the same bank, so the 16-bit `JSR ABS` reaches it.

--- a/config/config.py
+++ b/config/config.py
@@ -10,11 +10,20 @@ palette tables.  Their layout in ROM:
     bbb = battle speed     (0..5, displayed as 1..6)
 * Config2 -- byte loaded into $1D54: mbcc csss
 * Config3 -- byte loaded into $1D4E: gcsr wwww
+* Config4 -- byte loaded into $1D4F: ---- 4321
+    4321 = which battle character (slot 1..4) player 2 controls when the
+    Controller option is "multiple".  Each bit is the in-game submenu's
+    "if on, player 2 controls character N" toggle; the upper nibble is
+    unused.
 
-Config1 lives at a fixed address.  Config2/Config3 default writes are done
-by a pair of small subroutines whose addresses are stored as JSR operands
-at $03/70C3 and $03/70C6 -- we read those, then add 1 to skip past the
-"LDA #$NN" opcode and land on the immediate byte that we want to patch.
+Config1 lives at a fixed address.  Config2/Config3/Config4 default writes
+are done by small subroutines whose addresses are stored as JSR operands
+at $03/70C3, $03/70C6 and $03/70C9 -- we read those, then add 1 to skip
+past the "LDA #$NN" opcode and land on the immediate byte we want to patch.
+
+The Config4 ($1D4F) subroutine is an extension: vanilla/older trampolines
+only override Config2/Config3, leaving boot code's ``STZ $1D4F`` in place
+(a hard zero).  ``set_config`` detects whether the extension is present.
 
 Window palettes live at $2D/1C02 etc., 14 bytes (7 BGR15 colors) each.
 """
@@ -30,6 +39,7 @@ CONFIG1_ADDR = 0x0370B9
 # Same for $03/70C5.  Reading at +1 / +4 skips the opcode byte.
 CONFIG2_JSR_OPERAND = 0x0370C3
 CONFIG3_JSR_OPERAND = 0x0370C6
+CONFIG4_JSR_OPERAND = 0x0370C9
 
 FONT_PALETTE_ADDRS = (
     0x18E806,  # actual font color (2 bytes)
@@ -78,7 +88,16 @@ CONFIG_BYTES = {
         Field("Reequip",   bits=1, default=False),
         Field("Wallpaper", bits=4, default=1, offset=1),
     ],
+    "Config4": [   # ----4321
+        # Low nibble is a bitmask: bit N-1 set => player 2 controls battle
+        # slot N.  Stored as a 4-bit int (0..15); the high nibble stays 0.
+        Field("Player2Controls", bits=4, default=0),
+    ],
 }
+
+# CONFIG_BYTES entries written through the boot trampoline.  Config4
+# ($1D4F) is handled separately because it needs the trampoline extension.
+TRAMPOLINE_CONFIG_BYTES = ("Config2", "Config3")
 
 
 WINDOW_DEFAULTS = {
@@ -140,6 +159,22 @@ def is_trampoline_installed(rom):
             and rom.get_byte(CONFIG_TRAMPOLINE_JSR + 3) == 0x20)
 
 
+# The boot site for the Config4 ($1D4F) write sits right after the two
+# original STZ instructions.  Older trampolines leave a ``STZ $1D4F``
+# (opcode 0x9C) here; the extended trampoline replaces it with a JSR.
+CONTROLLER_TRAMPOLINE_JSR = CONFIG_TRAMPOLINE_JSR + 6  # 0x0370C8
+
+
+def is_controller_trampoline_installed(rom):
+    """Return True if the extended ``$03/70C8`` trampoline is in place.
+
+    This is the third JSR that lets us override the default value of
+    $1D4F (player-2 controller assignments).  Without it, $1D4F is a hard
+    zero baked in by the boot ``STZ`` and only a zero default is possible.
+    """
+    return rom.get_byte(CONTROLLER_TRAMPOLINE_JSR) == 0x20
+
+
 # ---- Public API ------------------------------------------------------
 
 def set_config(rom, config_set):
@@ -155,8 +190,21 @@ def set_config(rom, config_set):
         "Config2": _read_default_config_addr(rom, CONFIG2_JSR_OPERAND),
         "Config3": _read_default_config_addr(rom, CONFIG3_JSR_OPERAND),
     }
-    for name, fields in CONFIG_BYTES.items():
-        rom.set_bytes(addresses[name], [pack_config_byte(fields, config_set)])
+    for name in ("Config1", *TRAMPOLINE_CONFIG_BYTES):
+        rom.set_bytes(addresses[name], [pack_config_byte(CONFIG_BYTES[name], config_set)])
+
+    # Config4 ($1D4F) only exists once the trampoline extension is in.
+    # When it's absent, the boot ``STZ`` already gives a zero default, so
+    # we only need to complain if the user actually asked for non-zero.
+    p2_byte = pack_config_byte(CONFIG_BYTES["Config4"], config_set)
+    if is_controller_trampoline_installed(rom):
+        addr = _read_default_config_addr(rom, CONFIG4_JSR_OPERAND)
+        rom.set_bytes(addr, [p2_byte])
+    elif p2_byte:
+        raise ValueError(
+            "player-2 controller assignments need the extended config "
+            "trampoline ($03/70C8); re-run install_trampoline.py on this ROM."
+        )
 
     for i in range(1, 9):
         key = f"Window{i}"

--- a/ff6_config.py
+++ b/ff6_config.py
@@ -49,6 +49,31 @@ def _bool_choice(true_label, false_label):
     return parse
 
 
+def _parse_player2(s):
+    """Parse a subset of battle slots {1,2,3,4} into a 4-bit mask.
+
+    Accepts the digits 1..4 in any order, optionally separated by commas
+    or spaces (e.g. ``"13"``, ``"1,3"``).  Each listed slot N sets bit
+    N-1, matching the in-game submenu's ``----4321`` layout in $1D4F
+    ("if on, player 2 controls that character").  An empty string means
+    no slots (player 1 controls everyone).
+    """
+    mask = 0
+    seen = set()
+    for ch in s:
+        if ch in ", ":
+            continue
+        if ch not in "1234":
+            raise argparse.ArgumentTypeError(
+                f"player-2 slots must be a subset of {{1,2,3,4}}, got {s!r}")
+        n = int(ch)
+        if n in seen:
+            raise argparse.ArgumentTypeError(f"slot {n} listed twice in {s!r}")
+        seen.add(n)
+        mask |= 1 << (n - 1)
+    return mask
+
+
 def _parse_rgb(s):
     """Parse ``R,G,B`` (each 0..31) into ``[R, G, B]``."""
     parts = s.split(",")
@@ -121,7 +146,8 @@ def _parse_window_palette(s):
 # argparse namespace straight through to set_config.
 CLI_OPTIONS = [
     "BatMode", "BatSpeed", "MsgSpeed", "Command", "Gauge", "Sound",
-    "Cursor", "Reequip", "SpellOrder", "Controller2", "Font", "Wallpaper",
+    "Cursor", "Reequip", "SpellOrder", "Controller2", "Player2Controls",
+    "Font", "Wallpaper",
     *(f"Window{i}" for i in range(1, 9)),
 ]
 
@@ -166,6 +192,10 @@ def build_parser():
     p.add_argument("-ctrl","--controller",  dest="Controller2",
                    type=_bool_choice("multiple", "single"),
                    help="single | multiple  (default: single)")
+    p.add_argument("-p2",  "--player2",      dest="Player2Controls",
+                   type=_parse_player2,
+                   help="battle slots player 2 controls: subset of 1,2,3,4 "
+                        "(e.g. 13 or 1,3). Requires --controller multiple.")
     p.add_argument("-f",   "--font",        dest="Font",
                    type=_parse_rgb,
                    help="font color as R,G,B (each 0..31)")
@@ -240,6 +270,11 @@ def main(argv=None):
         if getattr(args, name) is not None
     }
 
+    # Player-2 assignments only make sense in "multiple" controller mode --
+    # the in-game submenu they map to is unreachable otherwise.
+    if config_set.get("Player2Controls") and not config_set.get("Controller2"):
+        sys.exit("error: -p2/--player2 requires -ctrl/--controller multiple")
+
     rom = ROM(args.input)
     if not cfg.is_trampoline_installed(rom):
         sys.exit(
@@ -248,7 +283,10 @@ def main(argv=None):
             "Run `python3 install_trampoline.py -i <rom>` first, or apply a "
             "Worlds Collide patch."
         )
-    cfg.set_config(rom, config_set)
+    try:
+        cfg.set_config(rom, config_set)
+    except ValueError as e:
+        sys.exit(f"error: {e}")
 
     # Apply --config graphics first, then --window-image, so an explicit
     # --window-image on the CLI overrides whatever the JSON has for the

--- a/install_trampoline.py
+++ b/install_trampoline.py
@@ -1,14 +1,15 @@
 """Install the FF6 default-config trampoline into a ROM.
 
-`ff6_config.py` only edits the immediate byte baked into a pair of
+`ff6_config.py` only edits the immediate byte baked into a set of
 config-default subroutines.  In a vanilla FF6 ROM those subroutines
-don't exist -- the boot code at file offset 0x0370C2 zeros $1D54 and
-$1D4E in place with two ``STZ ABS`` instructions and provides no way
-to override the defaults.
+don't exist -- the boot code at file offset 0x0370C2 zeros $1D54,
+$1D4E and $1D4F in place with three consecutive ``STZ ABS``
+instructions and provides no way to override the defaults.
 
-This script replaces those 6 bytes with two ``JSR ABS`` calls into a
-pair of 6-byte trampoline subroutines that `ff6_config` can later
-patch.
+This script replaces those 9 bytes with three ``JSR ABS`` calls into a
+trio of 6-byte trampoline subroutines that `ff6_config` can later
+patch.  The third subroutine ($1D4F) backs the player-2 controller
+assignments, settable only when the Controller option is "multiple".
 
 Default placement is at file offset 0x03F091 (SNES $C3/F091), which
 the published FF6 ROM map lists as the start of a 3951-byte unused
@@ -39,7 +40,7 @@ BANK_C3_FILE_START = 0x30000
 BANK_C3_FILE_END   = 0x40000   # exclusive
 
 DEFAULT_TRAMPOLINE_ADDR = 0x03F091
-TRAMPOLINE_SIZE = 12  # two 6-byte subroutines
+TRAMPOLINE_SIZE = 18  # three 6-byte subroutines
 
 STZ_OPCODE = 0x9C
 JSR_OPCODE = 0x20
@@ -48,10 +49,11 @@ JSR_OPCODE = 0x20
 # ---- Trampoline byte builders ---------------------------------------
 
 def build_subroutines():
-    """Return the 12 trampoline bytes: two LDA/STA/RTS subroutines.
+    """Return the 18 trampoline bytes: three LDA/STA/RTS subroutines.
 
     ff6_config patches the second byte of each subroutine (the LDA
-    immediate operand) to set the default value of Config2 / Config3.
+    immediate operand) to set the default value of Config2 / Config3 /
+    Config4 ($1D54 / $1D4E / $1D4F).
     """
     return [
         # Config2 (writes $1D54)
@@ -62,21 +64,25 @@ def build_subroutines():
         0xA9, 0x00,        # LDA #$00
         0x8D, 0x4E, 0x1D,  # STA $1D4E
         0x60,              # RTS
+        # Config4 (writes $1D4F -- player-2 controller assignments)
+        0xA9, 0x00,        # LDA #$00
+        0x8D, 0x4F, 0x1D,  # STA $1D4F
+        0x60,              # RTS
     ]
 
 
-def build_jsr_pair(snes_low_addr):
-    """Return the 6 bytes that replace the two STZ instructions.
+def build_jsrs(snes_low_addr):
+    """Return the 9 bytes that replace the three STZ instructions.
 
     ``snes_low_addr`` is the low 16 bits of the SNES address of the
-    Config2 subroutine; the Config3 subroutine lives 6 bytes later.
+    Config2 subroutine; the Config3 and Config4 subroutines live 6 and
+    12 bytes later.
     """
-    sub2 = snes_low_addr & 0xFFFF
-    sub3 = (snes_low_addr + 6) & 0xFFFF
-    return [
-        JSR_OPCODE, sub2 & 0xFF, (sub2 >> 8) & 0xFF,
-        JSR_OPCODE, sub3 & 0xFF, (sub3 >> 8) & 0xFF,
-    ]
+    out = []
+    for offset in (0, 6, 12):
+        sub = (snes_low_addr + offset) & 0xFFFF
+        out += [JSR_OPCODE, sub & 0xFF, (sub >> 8) & 0xFF]
+    return out
 
 
 # ---- CLI -------------------------------------------------------------
@@ -162,10 +168,11 @@ def main(argv=None):
 
     snes_low = target & 0xFFFF
     sub_bytes = build_subroutines()
-    jsr_bytes = build_jsr_pair(snes_low)
+    jsr_bytes = build_jsrs(snes_low)
 
     print(
-        f"WARNING: writing 12 bytes at file 0x{target:05X} (SNES $C3/{snes_low:04X}).\n"
+        f"WARNING: writing {TRAMPOLINE_SIZE} bytes at file 0x{target:05X} "
+        f"(SNES $C3/{snes_low:04X}).\n"
         "The FF6 ROM map lists this region as unused, but any other patch\n"
         "applied to this ROM that also writes here will be clobbered. If\n"
         "you're maintaining an FF6 project, install the trampoline as part\n"
@@ -175,10 +182,12 @@ def main(argv=None):
     print()
     print("Installing trampoline:")
     print(f"  Config2 sub  @ file 0x{target:05X}: "
-          f"{' '.join(f'{b:02X}' for b in sub_bytes[:6])}")
+          f"{' '.join(f'{b:02X}' for b in sub_bytes[0:6])}")
     print(f"  Config3 sub  @ file 0x{target + 6:05X}: "
-          f"{' '.join(f'{b:02X}' for b in sub_bytes[6:])}")
-    print(f"  JSR pair     @ file 0x{BOOT_JSR_SITE:05X}: "
+          f"{' '.join(f'{b:02X}' for b in sub_bytes[6:12])}")
+    print(f"  Config4 sub  @ file 0x{target + 12:05X}: "
+          f"{' '.join(f'{b:02X}' for b in sub_bytes[12:18])}")
+    print(f"  JSR trio     @ file 0x{BOOT_JSR_SITE:05X}: "
           f"{' '.join(f'{b:02X}' for b in jsr_bytes)}")
 
     rom.set_bytes(target, sub_bytes)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,19 @@ def test_pack_config2_defaults():
     assert cfg.pack_config_byte(cfg.CONFIG_BYTES["Config2"], {}) == 0
 
 
+def test_pack_config4_player2():
+    # Default: no slots -> 0
+    assert cfg.pack_config_byte(cfg.CONFIG_BYTES["Config4"], {}) == 0
+    # Slots 1 and 3 -> ----0101 = 0x05 (upper nibble stays clear)
+    byte = cfg.pack_config_byte(cfg.CONFIG_BYTES["Config4"],
+                                {"Player2Controls": 0b0101})
+    assert byte == 0b0101, f"{byte:#04x}"
+    # All four slots -> ----1111 = 0x0F
+    byte = cfg.pack_config_byte(cfg.CONFIG_BYTES["Config4"],
+                                {"Player2Controls": 0b1111})
+    assert byte == 0x0F, f"{byte:#04x}"
+
+
 def test_pack_config3_all_set():
     byte = cfg.pack_config_byte(
         cfg.CONFIG_BYTES["Config3"],
@@ -374,6 +387,68 @@ def test_set_config_writes_three_bytes():
     assert 0x03FC11 in written_addrs
 
 
+def test_parse_player2_masks():
+    assert ff6_config._parse_player2("") == 0
+    assert ff6_config._parse_player2("1") == 0b0001
+    assert ff6_config._parse_player2("13") == 0b0101
+    assert ff6_config._parse_player2("1,3") == 0b0101
+    assert ff6_config._parse_player2("1234") == 0b1111
+    # Order doesn't matter
+    assert ff6_config._parse_player2("42") == 0b1010
+
+
+def test_parse_player2_rejects_bad():
+    for bad in ["5", "0", "a", "12,5"]:
+        try:
+            ff6_config._parse_player2(bad)
+        except argparse.ArgumentTypeError:
+            pass
+        else:
+            raise AssertionError(f"expected rejection for {bad!r}")
+    # Duplicate slot
+    try:
+        ff6_config._parse_player2("11")
+    except argparse.ArgumentTypeError:
+        pass
+    else:
+        raise AssertionError("expected rejection for duplicate slot")
+
+
+def test_cli_parses_player2_and_controller():
+    parser = ff6_config.build_parser()
+    ns = parser.parse_args(["-i", "rom.smc", "-ctrl", "multiple", "-p2", "13"])
+    assert ns.Controller2 is True
+    assert ns.Player2Controls == 0b0101
+
+
+def test_set_config_writes_player2_when_extended():
+    rom_bytes = bytearray(0x300000)
+    rom_bytes[0x0370C3] = 0x00; rom_bytes[0x0370C4] = 0xFC  # Config2 -> 0x03FC01
+    rom_bytes[0x0370C6] = 0x10; rom_bytes[0x0370C7] = 0xFC  # Config3 -> 0x03FC11
+    rom_bytes[0x0370C8] = 0x20                              # extended trampoline JSR
+    rom_bytes[0x0370C9] = 0x20; rom_bytes[0x0370CA] = 0xFC  # Config4 -> 0x03FC21
+    rom = _FakeRom(rom_bytes)
+    cfg.set_config(rom, {"Player2Controls": 0b1010})
+    assert (0x03FC21, [0b1010]) in rom.writes
+
+
+def test_set_config_rejects_player2_without_extended_trampoline():
+    rom_bytes = bytearray(0x300000)
+    rom_bytes[0x0370C3] = 0x00; rom_bytes[0x0370C4] = 0xFC
+    rom_bytes[0x0370C6] = 0x10; rom_bytes[0x0370C7] = 0xFC
+    rom_bytes[0x0370C8] = 0x9C  # vanilla STZ $1D4F -- no Config4 override
+    rom = _FakeRom(rom_bytes)
+    # Zero request is fine (the STZ already gives a zero default).
+    cfg.set_config(rom, {"Player2Controls": 0})
+    # Non-zero request must fail loudly.
+    try:
+        cfg.set_config(rom, {"Player2Controls": 0b0001})
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError without extended trampoline")
+
+
 # ---- Trampoline detection -------------------------------------------
 
 def test_trampoline_detection():
@@ -393,22 +468,32 @@ def test_trampoline_detection():
     assert cfg.is_trampoline_installed(_FakeRom(rom_bytes)) is False
 
 
+def test_controller_trampoline_detection():
+    rom_bytes = bytearray(0x040000)
+    rom_bytes[0x0370C8] = 0x9C  # vanilla STZ $1D4F
+    assert cfg.is_controller_trampoline_installed(_FakeRom(rom_bytes)) is False
+    rom_bytes[0x0370C8] = 0x20  # extended trampoline JSR
+    assert cfg.is_controller_trampoline_installed(_FakeRom(rom_bytes)) is True
+
+
 # ---- Installer -------------------------------------------------------
 
 def test_build_subroutines_layout():
     b = inst.build_subroutines()
-    assert len(b) == 12
+    assert len(b) == 18
     # Subroutine 1: LDA #$00; STA $1D54; RTS
-    assert b[:6] == [0xA9, 0x00, 0x8D, 0x54, 0x1D, 0x60]
+    assert b[0:6] == [0xA9, 0x00, 0x8D, 0x54, 0x1D, 0x60]
     # Subroutine 2: LDA #$00; STA $1D4E; RTS
-    assert b[6:] == [0xA9, 0x00, 0x8D, 0x4E, 0x1D, 0x60]
+    assert b[6:12] == [0xA9, 0x00, 0x8D, 0x4E, 0x1D, 0x60]
+    # Subroutine 3: LDA #$00; STA $1D4F; RTS (player-2 controller byte)
+    assert b[12:18] == [0xA9, 0x00, 0x8D, 0x4F, 0x1D, 0x60]
 
 
-def test_build_jsr_pair_default_address():
+def test_build_jsrs_default_address():
     # Default trampoline at file 0x3F091 -> SNES $C3/F091, low 16 bits 0xF091.
-    # Second subroutine at offset +6 -> $C3/F097, low 16 bits 0xF097.
-    jsrs = inst.build_jsr_pair(0xF091)
-    assert jsrs == [0x20, 0x91, 0xF0, 0x20, 0x97, 0xF0]
+    # Subroutines at offsets +0/+6/+12 -> $F091/$F097/$F09D.
+    jsrs = inst.build_jsrs(0xF091)
+    assert jsrs == [0x20, 0x91, 0xF0, 0x20, 0x97, 0xF0, 0x20, 0x9D, 0xF0]
 
 
 def test_parse_address_forms():
@@ -466,10 +551,10 @@ def test_installer_main_writes_expected_bytes(tmp_path=None):
     assert len(write_calls) == 1
     out_path, out = write_calls[0]
     assert out_path == "out.smc"
-    # Expect JSR pair to default address ($C3/F091)
-    assert out[0x0370C2:0x0370C8] == bytes([0x20, 0x91, 0xF0, 0x20, 0x97, 0xF0])
-    # Expect the 12 trampoline bytes
-    assert out[0x03F091:0x03F09D] == bytes(inst.build_subroutines())
+    # Expect the JSR trio to the default address ($C3/F091)
+    assert out[0x0370C2:0x0370CB] == bytes(inst.build_jsrs(0xF091))
+    # Expect the 18 trampoline bytes
+    assert out[0x03F091:0x03F0A3] == bytes(inst.build_subroutines())
 
 
 def test_installer_rejects_out_of_bank_address():

--- a/web/README.md
+++ b/web/README.md
@@ -20,9 +20,12 @@ python3 -m http.server --directory web 8000
 * **Canvas (left)** — the FF6 config menu, page A or B, displayed at native
   256x224 and scaled 2x.  Cursor sits next to the current value for the
   active row; the yellow underline marks every row's current value.
-* **Side panel (right)** — preview-window picker, wallpaper picker, R/G/B
-  sliders for the currently-targeted color, reset buttons, and the
-  generated flagstring.
+* **Side panel (right)** — preview-window picker, wallpaper picker,
+  controller (`single`/`multiple`) picker, R/G/B sliders for the
+  currently-targeted color, reset buttons, and the generated flagstring.
+  Choosing `multiple` reveals four "Player 2 controls" checkboxes
+  (battle slots 1–4) that map to the `-p2` flag and the in-game
+  controller-assignment submenu; they hide again under `single`.
 
 ### Keyboard
 

--- a/web/index.html
+++ b/web/index.html
@@ -54,6 +54,15 @@
             <option value="multiple">multiple</option>
           </select>
         </div>
+        <div class="row" id="player2-row" style="display:none;">
+          <label>Player 2 controls:</label>
+          <span class="p2-toggles">
+            <label><input type="checkbox" class="player2" value="1"> 1</label>
+            <label><input type="checkbox" class="player2" value="2"> 2</label>
+            <label><input type="checkbox" class="player2" value="3"> 3</label>
+            <label><input type="checkbox" class="player2" value="4"> 4</label>
+          </span>
+        </div>
       </div>
 
       <div class="color-edit" id="color-edit">

--- a/web/main.js
+++ b/web/main.js
@@ -42,6 +42,7 @@ const TOGGLE_DEFAULTS = {
   Reequip:    'optimum',
   SpellOrder: 1,
   Controller: 'single',
+  Player2:    [],   // battle slots (1..4) player 2 controls in "multiple"
   Wallpaper:  1,
   WindowStyle: 1,   // which Window* palette is "active" for editing/preview
 };
@@ -1371,6 +1372,7 @@ function syncSidePanel() {
   // from the canvas (PAGE_A_OPTIONS) and the side-panel dropdown, so keep
   // the dropdown synced after every state mutation.
   document.getElementById('controller').value = state.Controller;
+  syncPlayer2UI();
 
   // preview-warning
   const warn = document.getElementById('preview-warning');
@@ -1461,7 +1463,29 @@ document.getElementById('wallpaper').addEventListener('change', (e) => {
 
 document.getElementById('controller').addEventListener('change', (e) => {
   state.Controller = e.target.value;
+  syncPlayer2UI();
   updateFlagString();
+});
+
+// Player-2 controller assignment toggles.  The row is only visible while
+// Controller is "multiple"; the four checkboxes mirror the in-game submenu
+// ("if on, player 2 controls battle slot N", $1D4F bits ----4321).
+function syncPlayer2UI() {
+  const row = document.getElementById('player2-row');
+  row.style.display = state.Controller === 'multiple' ? '' : 'none';
+  document.querySelectorAll('.player2').forEach(cb => {
+    cb.checked = state.Player2.includes(parseInt(cb.value, 10));
+  });
+}
+
+document.querySelectorAll('.player2').forEach(cb => {
+  cb.addEventListener('change', () => {
+    const n = parseInt(cb.value, 10);
+    const set = new Set(state.Player2);
+    if (cb.checked) set.add(n); else set.delete(n);
+    state.Player2 = [...set].sort((a, b) => a - b);
+    updateFlagString();
+  });
 });
 
 document.querySelectorAll('.tab').forEach(t => {
@@ -1514,6 +1538,10 @@ function buildFlagString() {
     args.push(`-so ${state.SpellOrder}`);
   if (state.Controller !== TOGGLE_DEFAULTS.Controller)
     args.push(`-ctrl ${state.Controller}`);
+  // Player-2 assignments only mean anything in "multiple" mode, and the
+  // CLI rejects -p2 without -ctrl multiple, so gate the flag on both.
+  if (state.Controller === 'multiple' && state.Player2.length)
+    args.push(`-p2 ${[...state.Player2].sort((a, b) => a - b).join('')}`);
   if (state.Wallpaper !== TOGGLE_DEFAULTS.Wallpaper)
     args.push(`-w ${state.Wallpaper}`);
   if (!deepEq(state.font, FONT_DEFAULT))
@@ -1585,6 +1613,20 @@ function shlexSplit(s) {
   return out;
 }
 
+function parsePlayer2(s) {
+  // Inverse of buildFlagString's -p2 emission: digits 1..4 (optionally
+  // comma/space separated) -> sorted array of slot numbers.
+  const out = [];
+  for (const ch of s) {
+    if (ch === ',' || ch === ' ') continue;
+    if (!'1234'.includes(ch))
+      throw new Error(`player-2 slot out of 1..4 in ${JSON.stringify(s)}`);
+    const n = parseInt(ch, 10);
+    if (!out.includes(n)) out.push(n);
+  }
+  return out.sort((a, b) => a - b);
+}
+
 function parseRgbTriple(s) {
   const parts = s.split(',');
   if (parts.length !== 3) throw new Error(`bad rgb triple ${JSON.stringify(s)}`);
@@ -1629,6 +1671,8 @@ function applyFlagString(flags) {
       state[spec.key] = spec.int ? parseInt(val, 10) : val;
     } else if (flag === '-f') {
       state.font = parseRgbTriple(val);
+    } else if (flag === '-p2') {
+      state.Player2 = parsePlayer2(val);
     } else if (/^-w[1-8]$/.test(flag)) {
       const n = parseInt(flag.slice(2), 10);
       for (const entry of val.split(';')) {

--- a/web/style.css
+++ b/web/style.css
@@ -98,6 +98,17 @@ main {
   font-size: 12px;
   color: #fc8;
 }
+.p2-toggles {
+  display: flex;
+  gap: 12px;
+}
+.p2-toggles label {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+}
 
 .color-edit h3 {
   margin: 0 0 10px 0;


### PR DESCRIPTION
The in-game Controller submenu, reachable only when "multiple" is selected, sets the lower four bits of $1D4F (----4321: "if on, player 2 controls character N").  Nothing drove that byte before; the boot code just zeroes it with a STZ.

Wire it up across all three surfaces:

  - install_trampoline.py: the boot code at $03/70C2 has three consecutive STZ (writing $1D54/$1D4E/$1D4F).  Extend the trampoline from two 6-byte subroutines to three, replacing the STZ $1D4F at $03/70C8 with a JSR so its default becomes patchable.

  - config/config.py: add a Config4 byte (Player2Controls, 4-bit mask) written to $1D4F.  set_config writes it only when the extended trampoline ($03/70C8 == JSR) is present; a non-zero request without it raises with a hint to re-run the installer, while a zero default is a no-op (the boot STZ already gives zero).

  - ff6_config.py: add `-p2`/`--player2` taking a subset of {1,2,3,4} (e.g. `13` or `1,3`) parsed into the 4-bit mask.  It requires `-ctrl multiple`, matching the in-game submenu's reachability.

  - web: add four "Player 2 controls" checkboxes beside the Controller picker, shown only when "multiple" is selected and hidden under "single".  They round-trip through buildFlagString/applyFlagString via the same `-p2` flag, so download/upload covers them.

Tests and README/web docs updated to match.