### PR TITLE
Add paint tools, Change configurator boot defaults: BatSpeed 6, MsgSpeed 1, Cursor memory

### DIFF
--- a/tests/test_encoder_js.js
+++ b/tests/test_encoder_js.js
@@ -168,5 +168,61 @@ run('bgr5_to_rgb8 + rgb8_to_bgr5 round-trip every 5-bit value', () => {
   }
 });
 
+run('encodeBMP -> decodeBMP recovers every pixel index exactly', () => {
+  const W = enc.SHEET_W, H = enc.SHEET_H;
+  const pixels = new Uint8Array(W * H);
+  for (let i = 0; i < pixels.length; i++) pixels[i] = (i * 7) % 8;
+  // Slot 0 = magenta sentinel; 1..7 distinct colours snapped to BGR5.
+  const pal = [[255, 0, 255]];
+  for (let s = 1; s < 8; s++) {
+    pal.push([enc.bgr5_to_rgb8((s * 3) % 32),
+              enc.bgr5_to_rgb8((s * 5) % 32),
+              enc.bgr5_to_rgb8((s * 7) % 32)]);
+  }
+  const bmp = enc.encodeBMP(pixels, pal);
+  if (bmp[0] !== 0x42 || bmp[1] !== 0x4D) throw new Error('missing BM magic');
+  const ab = bmp.buffer.slice(bmp.byteOffset, bmp.byteOffset + bmp.byteLength);
+  const dec = enc.decodeBMP(ab);
+  if (dec.width !== W || dec.height !== H)
+    throw new Error(`decoded ${dec.width}x${dec.height}`);
+  const key = c => (c[0] << 16) | (c[1] << 8) | c[2];
+  const slot = new Map(); pal.forEach((c, i) => slot.set(key(c), i));
+  for (let i = 0; i < pixels.length; i++) {
+    if (slot.get(key(dec.pixels[i])) !== pixels[i])
+      throw new Error(`pixel ${i} mismatch`);
+  }
+});
+
+run('decodeBMP reads a 24-bit bottom-up bitmap top-to-bottom', () => {
+  // Hand-build a 2x2 24-bit BMP.  File rows are bottom-up, so the first
+  // pixel row in the file is the *bottom* image row.
+  const W = 2, H = 2;
+  const rowSize = Math.floor((24 * W + 31) / 32) * 4;   // 8 bytes (6 + 2 pad)
+  const dataOff = 54;
+  const buf = new Uint8Array(dataOff + rowSize * H);
+  const dv = new DataView(buf.buffer);
+  buf[0] = 0x42; buf[1] = 0x4D;
+  dv.setUint32(2, buf.length, true);
+  dv.setUint32(10, dataOff, true);
+  dv.setUint32(14, 40, true);
+  dv.setInt32(18, W, true);
+  dv.setInt32(22, H, true);            // positive -> bottom-up
+  dv.setUint16(26, 1, true);
+  dv.setUint16(28, 24, true);
+  dv.setUint32(30, 0, true);
+  // BGR triples.  bottom row (file row 0): red, green; top row: blue, white.
+  const put = (off, r, g, b) => { buf[off] = b; buf[off + 1] = g; buf[off + 2] = r; };
+  put(dataOff + 0 * rowSize + 0, 255, 0, 0);   // bottom-left  red
+  put(dataOff + 0 * rowSize + 3, 0, 255, 0);   // bottom-right green
+  put(dataOff + 1 * rowSize + 0, 0, 0, 255);   // top-left     blue
+  put(dataOff + 1 * rowSize + 3, 255, 255, 255); // top-right  white
+  const dec = enc.decodeBMP(buf.buffer);
+  const eq = (c, r, g, b) => c[0] === r && c[1] === g && c[2] === b;
+  if (!eq(dec.pixels[0], 0, 0, 255)) throw new Error('top-left not blue');
+  if (!eq(dec.pixels[1], 255, 255, 255)) throw new Error('top-right not white');
+  if (!eq(dec.pixels[2], 255, 0, 0)) throw new Error('bottom-left not red');
+  if (!eq(dec.pixels[3], 0, 255, 0)) throw new Error('bottom-right not green');
+});
+
 console.log(`\n${passed}/${passed + failed.length} passed`);
 if (failed.length) process.exit(1);

--- a/web/designer.js
+++ b/web/designer.js
@@ -42,6 +42,9 @@
     currentWindow: SHARED.WindowStyle || 1,
     borderId: '__current__',          // synthetic "what's already there" entry
     selectedIndex: 1,
+    tool: 'paint',                    // 'paint' | 'fill'
+    brushSize: 1,                     // 1, 2, 4, 8 (pixels per side)
+    brushShape: 'square',             // 'square' | 'circle'
     isPainting: false,
     lastTexUpload: null,              // for "Re-quantize" -- per-window
     // For each window the user has touched, store a snapshot so cycling
@@ -340,13 +343,39 @@
     return { x, y };
   }
 
+  // Stamp the current brush (size + shape) centred on pixel (cx, cy).
+  function stampBrush(cx, cy) {
+    const s = ds.brushSize;
+    if (s <= 1) {
+      if (cx >= 0 && cx < SHEET_W && cy >= 0 && cy < SHEET_H)
+        ds.pixels[idx(cx, cy)] = ds.selectedIndex;
+      return;
+    }
+    // Top-left of the brush square, roughly centred on the cursor pixel.
+    const off = Math.floor((s - 1) / 2);
+    const x0 = cx - off, y0 = cy - off;
+    const r = s / 2;
+    const bcx = x0 + r, bcy = y0 + r;   // brush centre in pixel-space
+    for (let dy = 0; dy < s; dy++) {
+      for (let dx = 0; dx < s; dx++) {
+        const px = x0 + dx, py = y0 + dy;
+        if (px < 0 || px >= SHEET_W || py < 0 || py >= SHEET_H) continue;
+        if (ds.brushShape === 'circle') {
+          const ex = (px + 0.5) - bcx, ey = (py + 0.5) - bcy;
+          if (ex * ex + ey * ey > r * r) continue;
+        }
+        ds.pixels[idx(px, py)] = ds.selectedIndex;
+      }
+    }
+  }
+
   function paintLine(a, b) {
     let x0 = a.x, y0 = a.y, x1 = b.x, y1 = b.y;
     const dx = Math.abs(x1 - x0), dy = Math.abs(y1 - y0);
     const sx = x0 < x1 ? 1 : -1, sy = y0 < y1 ? 1 : -1;
     let err = dx - dy;
     while (true) {
-      ds.pixels[idx(x0, y0)] = ds.selectedIndex;
+      stampBrush(x0, y0);
       if (x0 === x1 && y0 === y1) break;
       const e2 = 2 * err;
       if (e2 > -dy) { err -= dy; x0 += sx; }
@@ -354,23 +383,48 @@
     }
   }
 
+  // 4-connected flood fill seeded at (sx, sy).  Constrained to the region
+  // the seed lives in (texture: y<32, border: y>=32) so a fill never bleeds
+  // across the divider between the two areas.
+  function floodFill(sx, sy) {
+    const target = ds.pixels[idx(sx, sy)];
+    const repl = ds.selectedIndex;
+    if (target === repl) return;
+    const yLo = sy < TEX_H ? 0 : TEX_H;
+    const yHi = sy < TEX_H ? TEX_H : SHEET_H;
+    const stack = [sx, sy];
+    while (stack.length) {
+      const y = stack.pop(), x = stack.pop();
+      if (x < 0 || x >= SHEET_W || y < yLo || y >= yHi) continue;
+      if (ds.pixels[idx(x, y)] !== target) continue;
+      ds.pixels[idx(x, y)] = repl;
+      stack.push(x + 1, y, x - 1, y, x, y + 1, x, y - 1);
+    }
+  }
+
   let lastPaintPx = null;
   canvas.addEventListener('mousedown', (e) => {
     const p = canvasToPixel(e);
     if (!p) return;
+    e.preventDefault();
+    if (ds.tool === 'fill') {
+      floodFill(p.x, p.y);
+      markCustomized();
+      render();
+      return;
+    }
     ds.isPainting = true;
     lastPaintPx = p;
-    ds.pixels[idx(p.x, p.y)] = ds.selectedIndex;
+    stampBrush(p.x, p.y);
     markCustomized();
     render();
-    e.preventDefault();
   });
   canvas.addEventListener('mousemove', (e) => {
     if (!ds.isPainting) return;
     const p = canvasToPixel(e);
     if (!p) return;
     if (lastPaintPx) paintLine(lastPaintPx, p);
-    else ds.pixels[idx(p.x, p.y)] = ds.selectedIndex;
+    else stampBrush(p.x, p.y);
     lastPaintPx = p;
     render();
   });
@@ -381,6 +435,37 @@
   canvas.addEventListener('mouseup', endPaint);
   canvas.addEventListener('mouseleave', endPaint);
   window.addEventListener('mouseup', endPaint);
+
+  // ---- tool / brush selectors ----------------------------------------
+
+  // Wire a segmented button group: clicking a button marks it active and
+  // calls onPick with its data-* value.
+  function wireSegGroup(hostId, dataAttr, onPick) {
+    const host = document.getElementById(hostId);
+    if (!host) return;
+    host.addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-' + dataAttr + ']');
+      if (!btn || !host.contains(btn)) return;
+      for (const b of host.querySelectorAll('button')) b.classList.remove('active');
+      btn.classList.add('active');
+      onPick(btn.dataset[dataAttr]);
+    });
+  }
+
+  // Brush size/shape only apply to the brush; grey them out under Fill.
+  function syncToolUi() {
+    const fill = ds.tool === 'fill';
+    for (const id of ['ds-brush-row', 'ds-shape-row']) {
+      const row = document.getElementById(id);
+      if (row) row.classList.toggle('disabled', fill);
+    }
+    canvas.style.cursor = fill ? 'cell' : 'crosshair';
+  }
+
+  wireSegGroup('ds-tool', 'tool', (v) => { ds.tool = v; syncToolUi(); });
+  wireSegGroup('ds-brush-size', 'size', (v) => { ds.brushSize = parseInt(v, 10); });
+  wireSegGroup('ds-brush-shape', 'shape', (v) => { ds.brushShape = v; });
+  syncToolUi();
 
   // ---- border preset / upload ----------------------------------------
 
@@ -473,6 +558,101 @@
     setStatus('texture re-quantized from upload', false);
     render();
   }
+
+  // ---- bitmap export / import (32x56 sheet) --------------------------
+  //
+  // A round-trip path parallel to the "interpret any image" texture upload:
+  // export writes the current sheet exactly, and import reads back a 32x56
+  // bitmap pixel-for-pixel.  Index 0 (transparent) uses a magenta sentinel
+  // so the editor shows it as a real, distinct colour.
+
+  const MAGENTA = [255, 0, 255];
+  function isMagenta(c) { return c[0] === 255 && c[1] === 0 && c[2] === 255; }
+  function colorKey(c) { return (c[0] << 16) | (c[1] << 8) | c[2]; }
+
+  // 8 RGB8 entries indexed by pixel value; slot 0 -> magenta sentinel.
+  function sheetPaletteRGB8() {
+    const pal = [MAGENTA.slice()];
+    for (let s = 1; s < NUM_PALETTE_SLOTS; s++) pal.push(paletteRGB8(s));
+    return pal;
+  }
+
+  document.getElementById('ds-bmp-export').addEventListener('click', () => {
+    const bmp = enc.encodeBMP(ds.pixels, sheetPaletteRGB8());
+    const file = new Blob([bmp], { type: 'image/bmp' });
+    const url = URL.createObjectURL(file);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ff6window${ds.currentWindow}.bmp`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+    setStatus(`exported window ${ds.currentWindow} as a ${SHEET_W}x${SHEET_H} .bmp`, false);
+  });
+
+  document.getElementById('ds-bmp-import').addEventListener('change', async (e) => {
+    const input = e.target;
+    const f = input.files && input.files[0];
+    if (!f) return;
+    try {
+      const decoded = enc.decodeBMP(await f.arrayBuffer());
+      if (decoded.width !== SHEET_W || decoded.height !== SHEET_H)
+        throw new Error(
+          `image is ${decoded.width}x${decoded.height}; need ${SHEET_W}x${SHEET_H}. ` +
+          `Use the texture upload to auto-fit other sizes.`);
+
+      // Collect distinct, non-transparent colours (first-seen order).
+      const seen = new Map();   // colorKey -> [r,g,b]
+      for (const c of decoded.pixels) {
+        if (isMagenta(c)) continue;
+        const k = colorKey(c);
+        if (!seen.has(k)) seen.set(k, c);
+      }
+      const maxColors = NUM_PALETTE_SLOTS - 1;   // 7 visible slots
+      if (seen.size > maxColors)
+        throw new Error(
+          `image has ${seen.size} colors; bitmap import supports at most ` +
+          `${maxColors} plus magenta transparency. ` +
+          `Use the texture upload to auto-quantize instead.`);
+
+      // Assign slots 1..7 light-to-dark, matching the quantiser's ordering.
+      const colors = [...seen.values()].sort((a, b) => lumin(b) - lumin(a));
+      const slotOf = new Map();
+      colors.forEach((c, i) => slotOf.set(colorKey(c), i + 1));
+
+      // Update slots 1..7.  rgb8 -> bgr5 is exact for colours that came from
+      // our own export; external colours snap to the nearest SNES value.
+      // Pad untouched slots with their current palette so nothing is lost.
+      const cur = SHARED.windows[ds.currentWindow];
+      const pal7 = [];
+      for (let i = 0; i < 7; i++) {
+        pal7.push(i < colors.length
+          ? [rgb8_to_bgr5(colors[i][0]), rgb8_to_bgr5(colors[i][1]), rgb8_to_bgr5(colors[i][2])]
+          : cur[i].slice());
+      }
+      ff6c.setPaletteBulk(ds.currentWindow, pal7);
+
+      // Map every pixel to its slot (magenta -> 0).
+      const px = new Uint8Array(SHEET_W * SHEET_H);
+      for (let i = 0; i < decoded.pixels.length; i++) {
+        const c = decoded.pixels[i];
+        px[i] = isMagenta(c) ? 0 : slotOf.get(colorKey(c));
+      }
+      ds.pixels = px;
+      ds.lastTexUpload = null;
+      ds.borderId = '__current__';
+      markCustomized();
+      render();
+      setStatus(
+        `imported ${f.name} (${seen.size} color` + (seen.size === 1 ? '' : 's') +
+        ') pixel-exact', false);
+    } catch (err) {
+      setStatus('bitmap import failed: ' + err.message, true);
+    } finally {
+      input.value = '';   // let the same file re-trigger "change"
+    }
+  });
 
   // ---- window banner + revert ----------------------------------------
 

--- a/web/encoder.js
+++ b/web/encoder.js
@@ -196,9 +196,124 @@
     return v < 0 ? 0 : v > 31 ? 31 : v;
   }
 
+  // ---- BMP import / export (32x56 sheet) ----------------------------
+  // Lets the user round-trip a sheet through an external pixel editor.
+  // encodeBMP writes an 8-bit indexed, uncompressed (BI_RGB), bottom-up
+  // Windows BMP whose colour table is the 8-entry window palette and whose
+  // pixel bytes are palette indices 0..7 -- so it carries exactly the same
+  // information ds.pixels does.  decodeBMP reads it (and most editor output)
+  // back to per-pixel RGB.
+
+  // pixels: Uint8Array(SHEET_W*SHEET_H) of indices 0..7.
+  // paletteRGB8: array indexed by pixel value -> [r,g,b] 0..255.
+  function encodeBMP(pixels, paletteRGB8) {
+    const w = SHEET_W, h = SHEET_H;
+    const rowSize = (w + 3) & ~3;          // pad each row to 4 bytes (32 stays 32)
+    const pixelArraySize = rowSize * h;
+    const TABLE = 256;                      // full colour table; only 0..7 used
+    const headerSize = 14 + 40 + TABLE * 4;
+    const fileSize = headerSize + pixelArraySize;
+    const buf = new Uint8Array(fileSize);
+    const dv = new DataView(buf.buffer);
+    // BITMAPFILEHEADER
+    buf[0] = 0x42; buf[1] = 0x4D;          // 'BM'
+    dv.setUint32(2, fileSize, true);
+    dv.setUint32(10, headerSize, true);    // pixel-data offset
+    // BITMAPINFOHEADER
+    dv.setUint32(14, 40, true);
+    dv.setInt32(18, w, true);
+    dv.setInt32(22, h, true);              // positive height -> bottom-up
+    dv.setUint16(26, 1, true);             // colour planes
+    dv.setUint16(28, 8, true);             // bits per pixel
+    dv.setUint32(30, 0, true);             // BI_RGB (uncompressed)
+    dv.setUint32(34, pixelArraySize, true);
+    dv.setInt32(38, 2835, true);           // ~72 DPI (X)
+    dv.setInt32(42, 2835, true);           // ~72 DPI (Y)
+    dv.setUint32(46, TABLE, true);         // colours used
+    dv.setUint32(50, 0, true);             // all colours important
+    // colour table, stored BGRA
+    let p = 54;
+    for (let i = 0; i < TABLE; i++) {
+      const c = paletteRGB8[i] || [0, 0, 0];
+      buf[p++] = c[2]; buf[p++] = c[1]; buf[p++] = c[0]; buf[p++] = 0;
+    }
+    // pixel array, bottom-up
+    for (let y = 0; y < h; y++) {
+      const srcRow = (h - 1 - y) * w;
+      let dst = headerSize + y * rowSize;
+      for (let x = 0; x < w; x++) buf[dst++] = pixels[srcRow + x] & 0xFF;
+    }
+    return buf;
+  }
+
+  // Decode an uncompressed Windows BMP into { width, height, pixels }, where
+  // pixels is a flat Array of [r,g,b] in row-major top-to-bottom order.
+  // Handles 1/4/8-bit indexed and 24/32-bit truecolour (BI_RGB, plus 32-bit
+  // BI_BITFIELDS read as BGRA).  Throws on anything it can't read.
+  function decodeBMP(arrayBuffer) {
+    const buf = new Uint8Array(arrayBuffer);
+    if (buf.length < 54 || buf[0] !== 0x42 || buf[1] !== 0x4D)
+      throw new Error('not a BMP file');
+    const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const dataOffset = dv.getUint32(10, true);
+    const dibSize = dv.getUint32(14, true);
+    const width = dv.getInt32(18, true);
+    const rawHeight = dv.getInt32(22, true);
+    const bpp = dv.getUint16(28, true);
+    const compression = dv.getUint32(30, true);
+    const topDown = rawHeight < 0;
+    const height = Math.abs(rawHeight);
+    if (width <= 0 || height <= 0) throw new Error('bad BMP dimensions');
+    if (compression !== 0 && !(compression === 3 && bpp === 32))
+      throw new Error('compressed BMPs are not supported -- save as an ' +
+                      'uncompressed (BI_RGB) bitmap');
+
+    let palette = null;
+    if (bpp <= 8) {
+      let clrUsed = dv.getUint32(46, true);
+      if (clrUsed === 0) clrUsed = 1 << bpp;
+      const tableOff = 14 + dibSize;
+      palette = [];
+      for (let i = 0; i < clrUsed; i++) {
+        const o = tableOff + i * 4;
+        palette.push([buf[o + 2], buf[o + 1], buf[o]]);   // BGRA -> RGB
+      }
+    }
+
+    const rowSize = Math.floor((bpp * width + 31) / 32) * 4;
+    const pixels = new Array(width * height);
+    for (let ry = 0; ry < height; ry++) {        // ry: output row, 0 = top
+      const fileRow = topDown ? ry : (height - 1 - ry);
+      const rowOff = dataOffset + fileRow * rowSize;
+      for (let x = 0; x < width; x++) {
+        let rgb;
+        if (bpp === 8) {
+          rgb = palette[buf[rowOff + x]] || [0, 0, 0];
+        } else if (bpp === 4) {
+          const b = buf[rowOff + (x >> 1)];
+          rgb = palette[(x & 1) ? (b & 0x0F) : (b >> 4)] || [0, 0, 0];
+        } else if (bpp === 1) {
+          const b = buf[rowOff + (x >> 3)];
+          rgb = palette[(b >> (7 - (x & 7))) & 1] || [0, 0, 0];
+        } else if (bpp === 24) {
+          const o = rowOff + x * 3;
+          rgb = [buf[o + 2], buf[o + 1], buf[o]];
+        } else if (bpp === 32) {
+          const o = rowOff + x * 4;
+          rgb = [buf[o + 2], buf[o + 1], buf[o]];          // assume BGRA
+        } else {
+          throw new Error('unsupported BMP bit depth ' + bpp);
+        }
+        pixels[ry * width + x] = rgb;
+      }
+    }
+    return { width, height, pixels };
+  }
+
   return {
     encodeTile4bpp, encodeSheet, encodePalette,
     decodeTile4bpp, decodeSheet, decodePalette,
+    encodeBMP, decodeBMP,
     medianCut, sortByLuminosity, lumin,
     bgr5_to_rgb8, rgb8_to_bgr5,
     SHEET_W, SHEET_H, SHEET_BYTES, PAL_BYTES, BLOB_BYTES,

--- a/web/index.html
+++ b/web/index.html
@@ -138,6 +138,32 @@
                  title="Custom 32x24 border image (optional)">
         </fieldset>
         <fieldset>
+          <legend>Tools</legend>
+          <div class="row">
+            <span class="ds-tool-label">Tool</span>
+            <div class="seg" id="ds-tool">
+              <button type="button" class="seg-btn active" data-tool="paint">Brush</button>
+              <button type="button" class="seg-btn" data-tool="fill" title="Paint bucket (flood fill)">Fill</button>
+            </div>
+          </div>
+          <div class="row" id="ds-brush-row">
+            <span class="ds-tool-label">Size</span>
+            <div class="seg" id="ds-brush-size">
+              <button type="button" class="seg-btn active" data-size="1">1&times;</button>
+              <button type="button" class="seg-btn" data-size="2">2&times;</button>
+              <button type="button" class="seg-btn" data-size="4">4&times;</button>
+              <button type="button" class="seg-btn" data-size="8">8&times;</button>
+            </div>
+          </div>
+          <div class="row" id="ds-shape-row">
+            <span class="ds-tool-label">Shape</span>
+            <div class="seg" id="ds-brush-shape">
+              <button type="button" class="seg-btn active" data-shape="square">Square</button>
+              <button type="button" class="seg-btn" data-shape="circle">Circle</button>
+            </div>
+          </div>
+        </fieldset>
+        <fieldset>
           <legend>Palette</legend>
           <div id="ds-swatches" class="swatches"></div>
           <div class="rgb-row">
@@ -157,6 +183,19 @@
           </div>
         </fieldset>
         <fieldset>
+          <legend>Bitmap (32&times;56)</legend>
+          <button id="ds-bmp-export" type="button"
+                  title="Export the current window sheet as a 32x56 indexed .bmp to edit in an external tool">Export .bmp</button>
+          <label class="ds-upload-config" for="ds-bmp-import">Import .bmp:</label>
+          <input type="file" id="ds-bmp-import" accept="image/bmp,.bmp"
+                 title="Import a 32x56 bitmap (up to 7 colors + magenta transparency) pixel-exact">
+          <p class="ds-fieldnote">
+            Index 0 (transparent) is exported as magenta. A 32&times;56 image
+            with up to 7 colors plus magenta is read back pixel-exact; other
+            sizes/colors should use the texture upload instead.
+          </p>
+        </fieldset>
+        <fieldset>
           <legend>Output</legend>
           <button id="ds-revert" type="button" disabled>Revert this window to default</button>
           <button id="ds-download" type="button">Download configuration (.json)</button>
@@ -173,10 +212,13 @@
         <div class="ds-overlay-lines"></div>
         <p class="hint">
           Click / drag in the canvas to paint with the selected palette color.
-          The top 32&times;32 area is the interior texture; the bottom
-          32&times;24 area is the border / frame.  Cycle the
-          <em>Preview window style</em> dropdown above to switch which window
-          you're designing.
+          Pick a brush size (1&ndash;8) and shape (square / circle), or switch
+          to the <em>Fill</em> tool to flood-fill a region.  The top
+          32&times;32 area is the interior texture; the bottom 32&times;24
+          area is the border / frame.  Cycle the <em>Preview window style</em>
+          dropdown above to switch which window you're designing, or use
+          <em>Export / Import .bmp</em> to round-trip the 32&times;56 sheet
+          through an external editor.
         </p>
       </div>
     </div>

--- a/web/main.js
+++ b/web/main.js
@@ -68,12 +68,28 @@ const NUMERIC_OPTS = {
   WindowStyle:[1,2,3,4,5,6,7,8],
 };
 
+// The selection the configurator boots with, and the target of "Reset
+// everything to defaults".  This intentionally differs from TOGGLE_DEFAULTS:
+// TOGGLE_DEFAULTS is the game's no-flag baseline (must match config.py) and
+// stays the flag-omission baseline used by buildFlagString / applyFlagString,
+// so flagstrings still round-trip.  Because these picks differ from that
+// baseline, a freshly loaded site already emits "-bs 6 -ms 1 -c memory" --
+// which is what makes them actually take effect when the CLI applies the
+// flagstring.  (BatMode = wait is already the baseline, so no -b is emitted.)
+const INITIAL_TOGGLES = {
+  ...TOGGLE_DEFAULTS,
+  BatMode:  'wait',
+  BatSpeed: 6,
+  MsgSpeed: 1,
+  Cursor:   'memory',
+};
+
 // ---------------- state ----------------
 
 const state = {
   page: 'A',
-  // toggles
-  ...structuredClone(TOGGLE_DEFAULTS),
+  // toggles (boot selection -- see INITIAL_TOGGLES)
+  ...structuredClone(INITIAL_TOGGLES),
   font: [...FONT_DEFAULT],
   windows: structuredClone(WINDOW_DEFAULTS),
   // editing: 'font' or {window: N, slot: 1..7}
@@ -1433,7 +1449,7 @@ document.getElementById('reset-color').addEventListener('click', () => {
 });
 
 document.getElementById('reset-all').addEventListener('click', () => {
-  Object.assign(state, structuredClone(TOGGLE_DEFAULTS));
+  Object.assign(state, structuredClone(INITIAL_TOGGLES));
   state.font = [...FONT_DEFAULT];
   state.windows = structuredClone(WINDOW_DEFAULTS);
   state.editing = { kind: 'font' };

--- a/web/style.css
+++ b/web/style.css
@@ -314,6 +314,32 @@ button:active { background: #2a2a3e; }
   color: #cfe5d4;
 }
 
+.ds-tool-label {
+  width: 44px;
+  flex: 0 0 44px;
+  color: #aab;
+  font-size: 12px;
+}
+.designer-controls .row.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+.designer-controls .seg-btn {
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.ds-fieldnote {
+  margin: 6px 0 0 0;
+  font-size: 11px;
+  color: #889;
+  line-height: 1.4;
+}
+#ds-bmp-export {
+  display: block;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
 #ds-revert {
   display: block;
   width: 100%;


### PR DESCRIPTION
The site now loads (and "Reset everything to defaults" returns) to
Battle Mode = wait, Battle Speed = 6, Message Speed = 1, Cursor = memory.

Introduces INITIAL_TOGGLES for the boot/reset selection, kept separate
from TOGGLE_DEFAULTS. TOGGLE_DEFAULTS stays the game's no-flag baseline
(matches config.py) and remains the flag-omission baseline for
buildFlagString and the absent-flag reset in applyFlagString, so
flagstrings still round-trip. Because the boot picks differ from that
baseline, a freshly loaded site already emits "-bs 6 -ms 1 -c memory" --
which is what makes the picks actually apply when the CLI runs the
flagstring. (Battle Mode = wait is already the baseline, so no -b.)