### PR TITLE
Keep window-palette edits synced between the configurator and designer

### DIFF
--- a/web/designer.js
+++ b/web/designer.js
@@ -836,8 +836,11 @@
     if (newWindow !== ds.currentWindow) {
       loadWindow(newWindow);   // re-renders inside
     } else {
-      // Palette / other change for the current window -- just re-render.
-      render();
+      // A configurator palette edit aimed at a specific slot: mirror the
+      // selection so this designer's swatch + R/G/B sliders track the same
+      // color instead of drifting out of sync.  (font edits send no slot.)
+      if (detail.slot >= 1 && detail.slot <= 7) ds.selectedIndex = detail.slot;
+      render();   // re-reads SHARED.windows for the canvas image + sliders
     }
   });
 

--- a/web/main.js
+++ b/web/main.js
@@ -118,6 +118,18 @@ function notifyStateChange(detail) {
                                          { detail: detail || {} }));
 }
 
+// Broadcast a palette-value edit so the custom-window designer mirrors the
+// change (and selects the same slot).  Shared by every control that nudges
+// an R/G/B channel: the canvas sliders, the keyboard, and the side-panel
+// sliders.  Carries the window/slot when a window slot is being edited so
+// the designer can follow along; font edits send nulls.
+function notifyPaletteEdit() {
+  const slot = state.editing.kind === 'slot' ? state.editing.slot : null;
+  notifyStateChange({ kind: 'palette',
+                      window: slot ? state.WindowStyle : null,
+                      slot });
+}
+
 // ---------------- menu layout ----------------
 //
 // All coordinates are in native 256x224 pixel space.  These rectangles are
@@ -1322,6 +1334,7 @@ function setChannel(ch, value) {
   render();
   syncSidePanel();
   updateFlagString();
+  notifyPaletteEdit();
 }
 
 // ---------------- input handling ----------------
@@ -1369,6 +1382,7 @@ function adjustChannel(ch, delta) {
   render();
   syncSidePanel();
   updateFlagString();
+  notifyPaletteEdit();
 }
 
 function selectCurrent() {
@@ -1477,10 +1491,23 @@ function syncSidePanel() {
     else state.windows[state.WindowStyle][state.editing.slot - 1][i] = v;
     render();
     updateFlagString();
-    notifyStateChange({ kind: 'palette',
-                        window: state.editing.kind === 'slot' ? state.WindowStyle : null,
-                        slot:   state.editing.kind === 'slot' ? state.editing.slot : null });
+    notifyPaletteEdit();
   });
+});
+
+// Designer -> configurator sync.  When a window-palette color is edited in
+// the custom-window designer (bottom half), it writes straight into
+// state.windows and emits this event.  Mirror the edited slot into the
+// editing bar and re-sync the top half so the two stay in lock-step.
+document.addEventListener('ff6c:stateChange', (e) => {
+  const detail = (e && e.detail) || {};
+  if (detail.kind !== 'palette-from-designer') return;
+  if (detail.slot >= 1 && detail.slot <= 7) {
+    state.editing = { kind: 'slot', slot: detail.slot };
+  }
+  syncSidePanel();
+  render();
+  updateFlagString();
 });
 
 // Target-kind buttons (Font / Window).


### PR DESCRIPTION
The simulated-window R/G/B sliders (canvas drag + keyboard) mutated the shared palette without broadcasting, so the custom-window designer never saw those edits. Now every channel edit goes through a shared notifyPaletteEdit() that emits a palette event carrying the active slot.

- The designer mirrors that slot as its selected swatch and re-renders, so its image AND its R/G/B sliders track the configurator.
- The configurator now listens for the designer's palette edits and mirrors the slot back into its editing bar, so the bottom half drives the top half too. Both directions stay in lock-step.