### PR TITLE
Add in-browser ROM patching via a Vercel Python function

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,8 @@
+# Keep the Vercel deploy lean: ship only the static site (web/), the Python
+# patching function (api/), and the library it pulls in (config/, ff6_config.py).
+# Everything below is dev-only and never served or imported at runtime.
+screenshots/
+tests/
+scripts/
+ARCHIVE.md
+install_trampoline.py

--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ The easiest way to use this tool is the web configurator:
 
 Set up the menu the way you want — battle/message speed, spell order,
 wallpaper, font and window-palette colors, even custom window graphics —
-then click **Download configuration** to save an `ff6config.json` file.
-That file bundles the chosen flags (and any custom window graphics) so you
-don't have to assemble a command line by hand.
+then either:
 
-To patch a ROM with it, pass the JSON to `ff6_config.py` with `--config`:
+* **Patch a ROM right there.** Pick your WC-patched ROM under *Patch a
+  ROM* and click **Patch & download ROM**. The site uploads the ROM to a
+  serverless function that runs the same `ff6_config` code path in memory
+  and streams the patched copy straight back. The ROM is never stored —
+  it is received, patched, and returned, with no copy retained.
+* **Download the config** (`ff6config.json`) to patch locally with the CLI.
+  That file bundles the chosen flags (and any custom window graphics) so
+  you don't have to assemble a command line by hand.
+
+To patch a ROM with the JSON locally, pass it to `ff6_config.py` with
+`--config`:
 
 ```sh
 python3 ff6_config.py -i ff6.smc --config ff6config.json

--- a/api/patch.py
+++ b/api/patch.py
@@ -1,0 +1,156 @@
+"""Vercel serverless function: patch an uploaded FF6 ROM in memory.
+
+The browser POSTs a ``multipart/form-data`` body with two fields:
+
+  * ``rom``    -- the raw .smc/.sfc bytes of an already-WC-patched ROM
+  * ``config`` -- the ``ff6config.json`` text the configurator builds
+                  (optional ``filename`` field names the download)
+
+We run the same patching code path as ``ff6_config.py`` entirely in RAM and
+stream the patched ROM straight back as the response body.  The uploaded ROM
+is never written to disk and nothing is retained after the request returns --
+the function is stateless and its filesystem is ephemeral regardless.
+
+Vercel runs this via the ``handler`` BaseHTTPRequestHandler convention; the
+shared ``config/`` package and ``ff6_config.py`` at the repo root are bundled
+through the ``includeFiles`` entry in ``vercel.json``.
+"""
+
+import json
+import os
+import re
+import sys
+from http.server import BaseHTTPRequestHandler
+
+# The patching library lives at the repository root, one level up from /api.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import ff6_config  # noqa: E402  (after sys.path tweak)
+
+# Hard ceiling on the uploaded body.  Vercel's own request-body limit (4.5 MB
+# on current plans) is stricter, but we guard here too so an oversized upload
+# fails fast with a clear message instead of a generic platform error.  An FF6
+# ROM is 3-4 MiB; 8 MiB leaves comfortable headroom for any expansion.
+MAX_BODY_BYTES = 8 * 1024 * 1024
+
+
+def _parse_multipart(content_type, body):
+    """Split a multipart/form-data body into ``{name: bytes}``.
+
+    Hand-rolled on the boundary bytes so binary ROM data survives intact
+    (the stdlib's text-oriented parsers can mangle it).
+    """
+    m = re.search(r'boundary=("?)([^";]+)\1', content_type or "")
+    if not m:
+        raise ValueError("not a multipart/form-data upload")
+    boundary = b"--" + m.group(2).encode("latin-1")
+
+    fields = {}
+    for segment in body.split(boundary):
+        # Skip the preamble, the closing "--", and empty separators.
+        segment = segment.strip(b"\r\n")
+        if not segment or segment == b"--":
+            continue
+        head, sep, data = segment.partition(b"\r\n\r\n")
+        if not sep:
+            continue
+        head_text = head.decode("latin-1", "replace")
+        name = re.search(r'name="([^"]*)"', head_text)
+        if not name:
+            continue
+        fields[name.group(1)] = data
+    return fields
+
+
+def _safe_filename(name, default="ff6_config.smc"):
+    """Turn an uploaded ROM name into ``<base>_config.smc`` for the download."""
+    if not name:
+        return default
+    base = os.path.basename(name)
+    for ext in (".smc", ".sfc"):
+        if base.lower().endswith(ext):
+            base = base[: -len(ext)]
+            break
+    base = re.sub(r"[^A-Za-z0-9._-]", "_", base).strip("._") or "ff6"
+    return f"{base}_config.smc"
+
+
+class handler(BaseHTTPRequestHandler):
+    # ---- helpers ----------------------------------------------------
+
+    def _send_error(self, status, message):
+        body = (message + "\n").encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    # ---- methods ----------------------------------------------------
+
+    def do_OPTIONS(self):
+        # CORS preflight (same-origin in normal use, but harmless to allow).
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self):
+        self._send_error(
+            405,
+            "POST a multipart/form-data body with 'rom' (the .smc bytes) and "
+            "'config' (ff6config.json) to patch a ROM.")
+
+    def do_POST(self):
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            return self._send_error(400, "bad Content-Length")
+        if length <= 0:
+            return self._send_error(400, "empty request body")
+        if length > MAX_BODY_BYTES:
+            return self._send_error(
+                413, f"upload too large ({length} bytes; max {MAX_BODY_BYTES})")
+
+        body = self.rfile.read(length)
+
+        try:
+            fields = _parse_multipart(self.headers.get("Content-Type"), body)
+        except ValueError as e:
+            return self._send_error(400, f"could not read upload: {e}")
+
+        rom_bytes = fields.get("rom")
+        if not rom_bytes:
+            return self._send_error(400, "missing 'rom' file in upload")
+
+        config = None
+        raw_config = fields.get("config")
+        if raw_config:
+            try:
+                config = json.loads(raw_config.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError) as e:
+                return self._send_error(400, f"invalid config JSON: {e}")
+            if not isinstance(config, dict):
+                return self._send_error(400, "config must be a JSON object")
+
+        try:
+            patched = ff6_config.patch_rom_bytes(rom_bytes, config)
+        except ff6_config.ConfigError as e:
+            return self._send_error(400, f"could not patch ROM: {e}")
+        except Exception:  # pragma: no cover - unexpected, keep it a 500
+            return self._send_error(500, "internal error patching ROM")
+
+        filename = _safe_filename(
+            (fields.get("filename") or b"").decode("utf-8", "replace"))
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header(
+            "Content-Disposition", f'attachment; filename="{filename}"')
+        self.send_header("Content-Length", str(len(patched)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(patched)

--- a/config/rom.py
+++ b/config/rom.py
@@ -2,13 +2,27 @@ class ROM():
     SHORT_PTR_SIZE = 2  # short ptr (16-bit)
     LONG_PTR_SIZE = 3   # long ptr  (24-bit)
 
-    def __init__(self, file_name):
-        with open(file_name, "rb") as rom_file:
-            self.data = list(rom_file.read())
+    def __init__(self, file_name=None, data=None):
+        # Two ways to build a ROM:
+        #   ROM("path.smc")     -- read the bytes from disk (CLI use)
+        #   ROM(data=b"...")    -- wrap bytes already in memory (web use)
+        # The in-memory form lets the web service patch an uploaded ROM
+        # without ever writing it to disk.
+        if data is not None:
+            self.data = list(data)
+        elif file_name is not None:
+            with open(file_name, "rb") as rom_file:
+                self.data = list(rom_file.read())
+        else:
+            raise ValueError("ROM requires either file_name or data")
 
 
     def size(self):
         return len(self.data)
+
+    def get_data(self):
+        """Return the current ROM image as bytes (no filesystem access)."""
+        return bytes(self.data)
 
     def write(self, file_name):
         with open(file_name, "wb") as out_file:

--- a/ff6_config.py
+++ b/ff6_config.py
@@ -16,6 +16,15 @@ from config import window_graphics as wg
 from config.rom import ROM
 
 
+class ConfigError(Exception):
+    """Invalid input while applying a config to an in-memory ROM.
+
+    Library callers (the web service) catch this and turn it into a 400 so a
+    bad upload never crashes the process; the CLI catches it and turns it into
+    a ``sys.exit`` message.
+    """
+
+
 # ---- argparse value parsers -----------------------------------------
 
 def _int_in_range(lo, hi):
@@ -230,6 +239,106 @@ def _default_output_path(input_path):
     return input_path + "_config.smc"
 
 
+# ---- reusable, file-free patching core ------------------------------
+#
+# These functions never touch the filesystem, so the web service can patch
+# an uploaded ROM entirely in memory and hand the bytes straight back without
+# ever storing a copy.  The CLI (``main``) layers file I/O on top of them.
+
+def _graphics_blobs_from_config(cfg_data):
+    """Decode a config dict's ``graphics`` map into ``[(window, blob), ...]``.
+
+    Each value is base64 of a 928-byte (graphics + palette) blob.  Raises
+    ConfigError on a bad window number, bad base64, or wrong-size blob.
+    """
+    expected = wg.WINDOW_GRAPHICS_SIZE + wg.WINDOW_PALETTE_FULL_SIZE
+    blobs = []
+    for n_str, b64 in (cfg_data.get("graphics") or {}).items():
+        try:
+            n = int(n_str)
+        except (TypeError, ValueError):
+            raise ConfigError(f"bad window number {n_str!r}")
+        if not 1 <= n <= 8:
+            raise ConfigError(f"bad window number {n}")
+        try:
+            blob = base64.b64decode(b64, validate=True)
+        except (ValueError, TypeError) as e:
+            raise ConfigError(f"window {n}: invalid base64 ({e})")
+        if len(blob) != expected:
+            raise ConfigError(
+                f"window {n} blob is {len(blob)} bytes, expected {expected}")
+        blobs.append((n, blob))
+    return blobs
+
+
+def apply_config(rom, args, graphics_blobs=()):
+    """Apply a parsed argparse namespace + graphics blobs to an in-memory ROM.
+
+    Mutates ``rom`` in place and returns it.  Raises ConfigError on any
+    invalid input (missing trampoline, bad palette, player-2 without
+    ``multiple``, duplicate window image, ...).  Touches no files.
+    """
+    config_set = {
+        name: getattr(args, name)
+        for name in CLI_OPTIONS
+        if getattr(args, name) is not None
+    }
+
+    # Player-2 assignments only make sense in "multiple" controller mode --
+    # the in-game submenu they map to is unreachable otherwise.
+    if config_set.get("Player2Controls") and not config_set.get("Controller2"):
+        raise ConfigError("-p2/--player2 requires -ctrl/--controller multiple")
+
+    if not cfg.is_trampoline_installed(rom):
+        raise ConfigError(
+            "ROM does not have the default-config trampoline installed at "
+            "$03/70C2. Patch the ROM with Worlds Collide first (or run "
+            "install_trampoline.py on a vanilla ROM).")
+
+    try:
+        cfg.set_config(rom, config_set)
+    except ValueError as e:
+        raise ConfigError(str(e))
+
+    seen = set()
+    for n, blob in graphics_blobs:
+        if n in seen:
+            raise ConfigError(f"window {n} graphics specified twice")
+        seen.add(n)
+        _apply_window_image_bytes(rom, n, blob)
+    return rom
+
+
+def patch_rom_bytes(rom_bytes, config=None, extra_flags=None):
+    """Patch an FF6 ROM held in memory and return the patched bytes.
+
+    ``config`` is a parsed ``ff6config.json`` dict (``version`` / ``flags`` /
+    ``graphics``) as produced by the web app, or None.  ``extra_flags`` is an
+    optional list of additional CLI flag tokens applied on top (they win over
+    the config's embedded flags, matching the CLI's ``--config`` behaviour).
+
+    Never reads or writes the filesystem.  Raises ConfigError on bad input.
+    """
+    flag_argv = []
+    graphics_blobs = []
+    if config is not None:
+        if config.get("version") != 1:
+            raise ConfigError(
+                f"unsupported config version {config.get('version')!r}")
+        flag_argv += shlex.split(config.get("flags", "") or "")
+        graphics_blobs = _graphics_blobs_from_config(config)
+    if extra_flags:
+        flag_argv += list(extra_flags)
+    try:
+        # "-i" is required by the parser but unused for in-memory patching.
+        args = build_parser().parse_args(["-i", "<memory>", *flag_argv])
+    except SystemExit:
+        raise ConfigError("invalid configuration flags")
+    rom = ROM(data=rom_bytes)
+    apply_config(rom, args, graphics_blobs)
+    return rom.get_data()
+
+
 def main(argv=None):
     raw_argv = sys.argv[1:] if argv is None else argv
     args = build_parser().parse_args(raw_argv)
@@ -251,49 +360,21 @@ def main(argv=None):
             re_argv += embedded + raw_argv
             args = build_parser().parse_args(re_argv)
         # Pull graphics out of the JSON.
-        for n_str, b64 in (cfg_data.get("graphics") or {}).items():
-            n = int(n_str)
-            if not 1 <= n <= 8:
-                sys.exit(f"error: {args.Config}: bad window number {n}")
-            blob = base64.b64decode(b64)
-            expected = wg.WINDOW_GRAPHICS_SIZE + wg.WINDOW_PALETTE_FULL_SIZE
-            if len(blob) != expected:
-                sys.exit(
-                    f"error: {args.Config}: window {n} blob is {len(blob)} "
-                    f"bytes, expected {expected}")
-            graphics_blobs.append((n, blob))
+        try:
+            graphics_blobs = _graphics_blobs_from_config(cfg_data)
+        except ConfigError as e:
+            sys.exit(f"error: {args.Config}: {e}")
 
     output_path = args.output or _default_output_path(args.input)
-    config_set = {
-        name: getattr(args, name)
-        for name in CLI_OPTIONS
-        if getattr(args, name) is not None
-    }
-
-    # Player-2 assignments only make sense in "multiple" controller mode --
-    # the in-game submenu they map to is unreachable otherwise.
-    if config_set.get("Player2Controls") and not config_set.get("Controller2"):
-        sys.exit("error: -p2/--player2 requires -ctrl/--controller multiple")
 
     rom = ROM(args.input)
-    if not cfg.is_trampoline_installed(rom):
-        sys.exit(
-            f"error: {args.input} does not have the default-config trampoline "
-            "installed at $03/70C2.\n"
-            "Run `python3 install_trampoline.py -i <rom>` first, or apply a "
-            "Worlds Collide patch."
-        )
     try:
-        cfg.set_config(rom, config_set)
-    except ValueError as e:
+        apply_config(rom, args, graphics_blobs)
+    except ConfigError as e:
         sys.exit(f"error: {e}")
 
-    # Apply --config graphics first, then --window-image, so an explicit
-    # --window-image on the CLI overrides whatever the JSON has for the
-    # same slot.
-    for n, blob in graphics_blobs:
-        _apply_window_image_bytes(rom, n, blob)
-
+    # --config graphics are applied above; explicit --window-image files on
+    # the CLI come last so they override whatever the JSON had for that slot.
     if args.WindowImage:
         seen = set()
         for n, path in args.WindowImage:
@@ -319,8 +400,8 @@ def _load_json_config(path):
 def _apply_window_image_bytes(rom, n, blob):
     expected = wg.WINDOW_GRAPHICS_SIZE + wg.WINDOW_PALETTE_FULL_SIZE
     if len(blob) != expected:
-        sys.exit(
-            f"error: window {n} blob: expected {expected} bytes "
+        raise ConfigError(
+            f"window {n} blob: expected {expected} bytes "
             f"({wg.WINDOW_GRAPHICS_SIZE} graphics + "
             f"{wg.WINDOW_PALETTE_FULL_SIZE} palette), got {len(blob)}")
     wg.set_window_graphics(rom, n, list(blob[: wg.WINDOW_GRAPHICS_SIZE]))
@@ -330,7 +411,10 @@ def _apply_window_image_bytes(rom, n, blob):
 def _apply_window_image(rom, n, path):
     """Read a 928-byte graphics+palette blob from ``path`` and patch window ``n``."""
     with open(path, "rb") as f:
-        _apply_window_image_bytes(rom, n, f.read())
+        try:
+            _apply_window_image_bytes(rom, n, f.read())
+        except ConfigError as e:
+            sys.exit(f"error: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -566,6 +566,87 @@ def test_installer_rejects_out_of_bank_address():
     raise AssertionError("expected SystemExit for out-of-bank address")
 
 
+# ---- in-memory patching (web service path) --------------------------
+
+def _trampolined_rom_bytes(size=0x2E0000):
+    """A minimal ROM image with the default-config trampoline installed."""
+    rom = bytearray(size)
+    rom[0x0370C2] = 0x20  # JSR (Config2)
+    rom[0x0370C5] = 0x20  # JSR (Config3)
+    rom[0x0370C3] = 0x91; rom[0x0370C4] = 0xF0  # Config2 sub -> $C3/F091 + 1
+    rom[0x0370C6] = 0x97; rom[0x0370C7] = 0xF0  # Config3 sub -> $C3/F097 + 1
+    return rom
+
+
+def test_patch_rom_bytes_applies_flags_and_graphics():
+    import base64
+    from config import config as _cfg
+
+    blob = bytes([0x55] * 896 + [0x00, 0x38] * 16)
+    config = {
+        "version": 1,
+        "flags": "-bs 5 -ms 2",
+        "graphics": {"7": base64.b64encode(blob).decode("ascii")},
+    }
+    out = ff6_config.patch_rom_bytes(_trampolined_rom_bytes(), config)
+
+    assert isinstance(out, (bytes, bytearray))
+    # Config1: BatSpeed=5 (100), MsgSpeed=2 (001), Command=0, BatMode=1
+    assert out[_cfg.CONFIG1_ADDR] == 0b00011100, f"{out[_cfg.CONFIG1_ADDR]:#04x}"
+    gfx_off = 0x2D0000 + 6 * 0x380
+    assert out[gfx_off:gfx_off + 896] == blob[:896]
+    pal_off = 0x2D1C00 + 6 * 0x20
+    assert out[pal_off:pal_off + 32] == blob[896:]
+
+
+def test_patch_rom_bytes_extra_flags_override_config():
+    from config import config as _cfg
+    config = {"version": 1, "flags": "-bs 5"}
+    out = ff6_config.patch_rom_bytes(
+        _trampolined_rom_bytes(), config, extra_flags=["-bs", "6"])
+    # BatSpeed=6 (101), MsgSpeed=3 (010), Command=0, BatMode=1 -> 0x2D
+    assert out[_cfg.CONFIG1_ADDR] == 0b00101101, f"{out[_cfg.CONFIG1_ADDR]:#04x}"
+
+
+def test_patch_rom_bytes_requires_trampoline():
+    # A vanilla (no-trampoline) ROM must raise ConfigError, not crash.
+    try:
+        ff6_config.patch_rom_bytes(bytearray(0x2E0000), {"version": 1, "flags": ""})
+    except ff6_config.ConfigError as e:
+        assert "trampoline" in str(e)
+        return
+    raise AssertionError("expected ConfigError without trampoline")
+
+
+def test_patch_rom_bytes_rejects_bad_version():
+    try:
+        ff6_config.patch_rom_bytes(_trampolined_rom_bytes(), {"version": 2})
+    except ff6_config.ConfigError as e:
+        assert "version" in str(e)
+        return
+    raise AssertionError("expected ConfigError for unsupported version")
+
+
+def test_patch_rom_bytes_rejects_wrong_size_graphics():
+    import base64
+    bad = base64.b64encode(b"\x00" * 100).decode("ascii")
+    config = {"version": 1, "flags": "", "graphics": {"3": bad}}
+    try:
+        ff6_config.patch_rom_bytes(_trampolined_rom_bytes(), config)
+    except ff6_config.ConfigError as e:
+        assert "expected" in str(e)
+        return
+    raise AssertionError("expected ConfigError for wrong-size graphics blob")
+
+
+def test_patch_rom_bytes_does_not_mutate_input():
+    src = _trampolined_rom_bytes()
+    snapshot = bytes(src)
+    ff6_config.patch_rom_bytes(src, {"version": 1, "flags": "-bs 6"})
+    # ROM(data=...) copies, so the caller's buffer is untouched.
+    assert bytes(src) == snapshot
+
+
 # ---- runner ----------------------------------------------------------
 
 def main():

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
+  "functions": {
+    "api/patch.py": {
+      "includeFiles": "{ff6_config.py,config/**}"
+    }
+  },
+  "rewrites": [
+    { "source": "/", "destination": "/web/index.html" },
+    { "source": "/((?!api/).*)", "destination": "/web/$1" }
+  ],
   "headers": [
     {
       "source": "/(.*)",

--- a/web/designer.js
+++ b/web/designer.js
@@ -675,7 +675,10 @@
 
   // ---- download (unified config JSON) --------------------------------
 
-  document.getElementById('ds-download').addEventListener('click', () => {
+  // Build the unified { version, flags, graphics } config object from the
+  // current designer + configurator state.  Shared by the JSON download and
+  // the "patch a ROM" upload so the two can never drift apart.
+  function buildConfigObject() {
     snapshotCurrent();
     const graphics = {};
     for (const [nStr, c] of Object.entries(ds.customGraphics)) {
@@ -691,11 +694,15 @@
       for (const b of all) bin += String.fromCharCode(b);
       graphics[nStr] = btoa(bin);
     }
-    const cfg = {
+    return {
       version: 1,
       flags: (ff6c.getFlagString && ff6c.getFlagString()) || '',
       graphics,
     };
+  }
+
+  document.getElementById('ds-download').addEventListener('click', () => {
+    const cfg = buildConfigObject();
     const json = JSON.stringify(cfg, null, 2);
     const file = new Blob([json], { type: 'application/json' });
     const url = URL.createObjectURL(file);
@@ -706,12 +713,69 @@
     a.click();
     document.body.removeChild(a);
     setTimeout(() => URL.revokeObjectURL(url), 1000);
-    const customCount = Object.keys(graphics).length;
+    const customCount = Object.keys(cfg.graphics).length;
     setStatus(
       `downloaded ff6config.json (${customCount} custom window` +
       (customCount === 1 ? '' : 's') + ') -- apply with ' +
       '`ff6_config.py -i rom.smc --config ff6config.json`', false);
   });
+
+  // ---- patch a ROM on the server (upload -> patch -> download) -------
+  //
+  // POSTs the uploaded ROM + the current config to the /api/patch function,
+  // which patches it in memory and streams the result straight back.  The
+  // ROM is never stored server-side.
+  const romInput = document.getElementById('ds-rom-upload');
+  const patchBtn = document.getElementById('ds-rom-patch');
+  if (romInput && patchBtn) {
+    patchBtn.addEventListener('click', async () => {
+      const f = romInput.files && romInput.files[0];
+      if (!f) {
+        setStatus('choose a ROM (.smc / .sfc) to patch first', true);
+        return;
+      }
+      const cfg = buildConfigObject();
+      patchBtn.disabled = true;
+      setStatus(`patching ${f.name}…`, false);
+      try {
+        const form = new FormData();
+        form.append('rom', f, f.name);
+        form.append('config', JSON.stringify(cfg));
+        form.append('filename', f.name);
+
+        const resp = await fetch('/api/patch', { method: 'POST', body: form });
+        if (!resp.ok) {
+          const msg = (await resp.text().catch(() => '')).trim();
+          throw new Error(msg || `HTTP ${resp.status} ${resp.statusText}`);
+        }
+
+        const blob = await resp.blob();
+        // Prefer the server's suggested filename; fall back locally.
+        let name = (f.name || 'ff6').replace(/\.(smc|sfc)$/i, '') + '_config.smc';
+        const cd = resp.headers.get('Content-Disposition') || '';
+        const m = cd.match(/filename="([^"]+)"/);
+        if (m) name = m[1];
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+
+        const customCount = Object.keys(cfg.graphics).length;
+        setStatus(
+          `patched ${f.name} → ${name} (${customCount} custom window` +
+          (customCount === 1 ? '' : 's') + ')', false);
+      } catch (err) {
+        setStatus('patch failed: ' + err.message, true);
+      } finally {
+        patchBtn.disabled = false;
+      }
+    });
+  }
 
   // ---- upload (restore from previously downloaded JSON) -------------
 

--- a/web/index.html
+++ b/web/index.html
@@ -234,6 +234,18 @@
     <!-- Output tools: below the column row -->
     <div class="designer-output">
       <button id="ds-download" type="button">Download configuration (.json)</button>
+      <div class="ds-patch-rom">
+        <label class="ds-upload-config" for="ds-rom-upload">Patch a ROM (.smc / .sfc):</label>
+        <input type="file" id="ds-rom-upload" accept=".smc,.sfc,application/octet-stream">
+        <button id="ds-rom-patch" type="button">Patch &amp; download ROM</button>
+      </div>
+      <p class="hint">
+        Applies the configuration above to your ROM and returns the patched
+        copy. The ROM must already be patched by
+        <a href="https://ff6worldscollide.com/">Worlds Collide</a>. Your ROM is
+        sent to the server, patched in memory, and handed straight back &mdash;
+        it is never stored.
+      </p>
       <div id="ds-status" class="ds-status"></div>
     </div>
   </section>

--- a/web/style.css
+++ b/web/style.css
@@ -236,6 +236,17 @@ button:active { background: #2a2a3e; }
   margin-top: 20px;
   max-width: 320px;
 }
+.designer-output .hint { margin: 8px 0 0 0; color: #aab; font-size: 13px; }
+.ds-patch-rom {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #444;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ds-patch-rom .ds-upload-config { color: #aab; font-size: 13px; }
+.ds-patch-rom input[type=file] { color: #cfe; font-size: 12px; }
 
 .designer-controls fieldset {
   border: 1px solid #444;


### PR DESCRIPTION
Let the web configurator patch an uploaded ROM directly instead of only producing an ff6config.json to apply by hand. The ROM is uploaded, patched in memory, and streamed straight back; it is never stored.

Backend:
- config/rom.py: ROM can be built from bytes (data=) and serialized with get_data(), so patching needs no filesystem.
- ff6_config.py: extract a reusable, file-free core -- ConfigError plus apply_config()/patch_rom_bytes() -- shared by the CLI and the web function. CLI behavior and messages are preserved (vanilla ROMs still exit cleanly with a trampoline hint).
- api/patch.py: Vercel serverless function (BaseHTTPRequestHandler) that parses the multipart upload, runs patch_rom_bytes, and returns the patched ROM as an attachment. Validates input and returns 400 on bad uploads rather than 500.

Frontend:
- web/index.html + designer.js: "Patch a ROM" control that POSTs the ROM and current config to /api/patch and downloads the result. Config building is factored into a shared buildConfigObject() used by both the JSON download and the patch upload.
- web/style.css: styling for the new control.

Deploy config:
- vercel.json moved to the repo root so the function can import the shared config/ package; rewrites serve the static site from web/, includeFiles bundles the patching library. .vercelignore trims dev-only files.

Tests: in-memory patch round-trip, flag overrides, version/size/trampoline rejection, and input-immutability.