### PR TITLE
Clean up the menu configurator web UI

### DIFF
--- a/web/designer.js
+++ b/web/designer.js
@@ -841,10 +841,8 @@
       // user lands on something visible instead of an untouched window.
       const target = decoded.length ? decoded[0].n : ds.currentWindow;
       ds.currentWindow = target;
-      const sel = document.getElementById('window-style');
-      if (sel && parseInt(sel.value, 10) !== target) {
-        sel.value = String(target);
-        sel.dispatchEvent(new Event('change'));
+      if (SHARED.WindowStyle !== target && ff6c.setWindowStyle) {
+        ff6c.setWindowStyle(target);
       }
       const cur = ds.customGraphics[target];
       if (cur && cur.pixels) {

--- a/web/index.html
+++ b/web/index.html
@@ -38,34 +38,12 @@
     </section>
 
     <section class="side">
-      <div class="window-picker">
-        <div class="row">
-          <label>Preview window style:</label>
-          <select id="window-style">
-            <option value="1">1</option><option value="2">2</option>
-            <option value="3">3</option><option value="4">4</option>
-            <option value="5">5</option><option value="6">6</option>
-            <option value="7">7</option><option value="8">8</option>
-          </select>
-          <span id="preview-warning" class="warn"></span>
-        </div>
-        <div class="row">
-          <label>Wallpaper (1..8):</label>
-          <select id="wallpaper">
-            <option value="1">1</option><option value="2">2</option>
-            <option value="3">3</option><option value="4">4</option>
-            <option value="5">5</option><option value="6">6</option>
-            <option value="7">7</option><option value="8">8</option>
-          </select>
-        </div>
-        <div class="row">
-          <label>Controller:</label>
-          <select id="controller">
-            <option value="single">single</option>
-            <option value="multiple">multiple</option>
-          </select>
-        </div>
-        <div class="row" id="player2-row" style="display:none;">
+      <!-- Window style, wallpaper, and controller are all chosen directly on
+           the simulated menu above, so this tile only carries the Player-2
+           battle-slot assignment (which has no on-canvas equivalent) and is
+           hidden entirely outside "multiple" controller mode. -->
+      <div class="window-picker" id="window-picker" style="display:none;">
+        <div class="row" id="player2-row">
           <label>Player 2 controls:</label>
           <span class="p2-toggles">
             <label><input type="checkbox" class="player2" value="1"> 1</label>
@@ -78,6 +56,7 @@
 
       <div class="color-edit" id="color-edit">
         <h3 id="color-edit-title">Editing: Font color</h3>
+        <p id="preview-warning" class="warn"></p>
         <div class="target-row">
           <label>Target:</label>
           <div class="seg" id="target-kind">
@@ -129,9 +108,13 @@
       <h2>Custom window image</h2>
       <p class="hint">
         Upload a 32&times;32 image as the window's interior texture, pick a
-        border treatment, paint any tweaks, then download as a 928-byte
-        binary.  Apply with
-        <code>ff6_config.py --window-image N:file.bin</code>.
+        border treatment, and paint any tweaks.  Everything you change here
+        &mdash; the custom graphics, palette colors, and every menu setting
+        above &mdash; is bundled into a single configuration file.  Use the
+        buttons at the bottom of the page to export it as
+        <code>ff6config.json</code> (apply with
+        <code>ff6_config.py -i rom.smc --config ff6config.json</code>) or to
+        patch a ROM straight from your browser.
       </p>
     </header>
     <div class="designer-grid">
@@ -160,12 +143,13 @@
             sizes/colors should use the texture upload instead.
           </p>
         </fieldset>
-        <fieldset>
-          <legend>Revert</legend>
-          <button id="ds-revert" type="button" disabled>Revert this window to default</button>
-        </fieldset>
       </div>
-      <!-- Column 2: paint tools -->
+      <!-- Column 2: canvas -->
+      <div class="designer-canvas-wrap">
+        <canvas id="ds-sheet" width="256" height="448"></canvas>
+        <div class="ds-overlay-lines"></div>
+      </div>
+      <!-- Column 3: paint tools -->
       <div class="designer-controls designer-col">
         <fieldset>
           <legend>Tools</legend>
@@ -214,40 +198,45 @@
         </fieldset>
         <button id="ds-bmp-export" type="button"
                 title="Export the current window sheet as a 32x56 indexed .bmp to edit in an external tool">Export .bmp</button>
-      </div>
-      <!-- Column 3: canvas -->
-      <div class="designer-canvas-wrap">
-        <canvas id="ds-sheet" width="256" height="448"></canvas>
-        <div class="ds-overlay-lines"></div>
-        <p class="hint">
-          Click / drag in the canvas to paint with the selected palette color.
-          Pick a brush size (1&ndash;8) and shape (square / circle), or switch
-          to the <em>Fill</em> tool to flood-fill a region.  The top
-          32&times;32 area is the interior texture; the bottom 32&times;24
-          area is the border / frame.  Cycle the <em>Preview window style</em>
-          dropdown above to switch which window you're designing, or use
-          <em>Export / Import .bmp</em> to round-trip the 32&times;56 sheet
-          through an external editor.
-        </p>
+        <button id="ds-revert" type="button" disabled>Revert this window to default</button>
       </div>
     </div>
-    <!-- Output tools: below the column row -->
-    <div class="designer-output">
-      <button id="ds-download" type="button">Download configuration (.json)</button>
+    <!-- Full-width note running the length of the tile, under the columns. -->
+    <p class="hint designer-note">
+      Click / drag in the canvas to paint with the selected palette color.
+      Pick a brush size (1&ndash;8) and shape (square / circle), or switch
+      to the <em>Fill</em> tool to flood-fill a region.  The top
+      32&times;32 area is the interior texture; the bottom 32&times;24
+      area is the border / frame.  Choose which window you're designing
+      straight from the simulated menu at the top of the page
+      (Page&nbsp;B &rarr; Window style), or use <em>Export / Import .bmp</em>
+      to round-trip the 32&times;56 sheet through an external editor.
+    </p>
+  </section>
+
+  <!-- Export / patch tile.  Lives in its own tile at the bottom because these
+       two actions bundle up everything changed above, not just the window
+       image. -->
+  <section class="output-tile">
+    <h2>Export &amp; patch</h2>
+    <div class="output-actions">
+      <button id="ds-download" type="button">Export configuration (.json)</button>
       <div class="ds-patch-rom">
         <label class="ds-upload-config" for="ds-rom-upload">Patch a ROM (.smc / .sfc):</label>
         <input type="file" id="ds-rom-upload" accept=".smc,.sfc,application/octet-stream">
         <button id="ds-rom-patch" type="button">Patch &amp; download ROM</button>
       </div>
-      <p class="hint">
-        Applies the configuration above to your ROM and returns the patched
-        copy. The ROM must already be patched by
-        <a href="https://ff6worldscollide.com/">Worlds Collide</a>. Your ROM is
-        sent to the server, patched in memory, and handed straight back &mdash;
-        it is never stored.
-      </p>
-      <div id="ds-status" class="ds-status"></div>
     </div>
+    <p class="hint">
+      <em>Export configuration (.json)</em> bundles every menu setting and
+      custom window image above into a single <code>ff6config.json</code>.
+      <em>Patch a ROM</em> applies that same configuration to your ROM and
+      returns the patched copy; the ROM must already be patched by
+      <a href="https://ff6worldscollide.com/">Worlds Collide</a>.  Your ROM is
+      sent to the server, patched in memory, and handed straight back &mdash;
+      it is never stored.
+    </p>
+    <div id="ds-status" class="ds-status"></div>
   </section>
 
   <!-- cache-bust on every load so iterative dev keeps in step with the

--- a/web/main.js
+++ b/web/main.js
@@ -1403,7 +1403,6 @@ function selectValue(row, val) {
   } else if (row.key === 'WindowStyle') {
     state.WindowStyle = val;
     loadWindowAssets(val).then(render);
-    document.getElementById('window-style').value = String(val);
   } else {
     state[row.key] = val;
   }
@@ -1468,10 +1467,8 @@ function syncSidePanel() {
   slotSel.disabled = isFont;
   if (!isFont) slotSel.value = String(state.editing.slot);
 
-  // Side-panel selects that mirror state.  Controller can be cycled both
-  // from the canvas (PAGE_A_OPTIONS) and the side-panel dropdown, so keep
-  // the dropdown synced after every state mutation.
-  document.getElementById('controller').value = state.Controller;
+  // Controller is cycled from the canvas (PAGE_A_OPTIONS); keep the
+  // Player-2 sub-panel in step with the current controller mode.
   syncPlayer2UI();
 
   // preview-warning
@@ -1551,41 +1548,19 @@ document.getElementById('reset-all').addEventListener('click', () => {
   state.windows = structuredClone(WINDOW_DEFAULTS);
   state.editing = { kind: 'font' };
   state.cursor = 0;
-  document.getElementById('window-style').value = '1';
-  document.getElementById('wallpaper').value = '1';
-  document.getElementById('controller').value = 'single';
   loadWindowAssets(1).then(() => {
     syncSidePanel(); render(); updateFlagString();
     notifyStateChange({ kind: 'reset-all' });
   });
 });
 
-document.getElementById('window-style').addEventListener('change', (e) => {
-  const v = parseInt(e.target.value, 10);
-  state.WindowStyle = v;
-  loadWindowAssets(v).then(() => {
-    syncSidePanel(); render(); updateFlagString();
-    notifyStateChange({ kind: 'windowStyle', value: v });
-  });
-});
-
-document.getElementById('wallpaper').addEventListener('change', (e) => {
-  state.Wallpaper = parseInt(e.target.value, 10);
-  updateFlagString();
-});
-
-document.getElementById('controller').addEventListener('change', (e) => {
-  state.Controller = e.target.value;
-  syncPlayer2UI();
-  updateFlagString();
-});
-
-// Player-2 controller assignment toggles.  The row is only visible while
-// Controller is "multiple"; the four checkboxes mirror the in-game submenu
-// ("if on, player 2 controls battle slot N", $1D4F bits ----4321).
+// Player-2 controller assignment toggles.  The picker tile is only visible
+// while Controller is "multiple" (chosen on the canvas); the four checkboxes
+// mirror the in-game submenu ("if on, player 2 controls battle slot N",
+// $1D4F bits ----4321).
 function syncPlayer2UI() {
-  const row = document.getElementById('player2-row');
-  row.style.display = state.Controller === 'multiple' ? '' : 'none';
+  const picker = document.getElementById('window-picker');
+  picker.style.display = state.Controller === 'multiple' ? '' : 'none';
   document.querySelectorAll('.player2').forEach(cb => {
     cb.checked = state.Player2.includes(parseInt(cb.value, 10));
   });
@@ -1655,8 +1630,10 @@ function buildFlagString() {
   // CLI rejects -p2 without -ctrl multiple, so gate the flag on both.
   if (state.Controller === 'multiple' && state.Player2.length)
     args.push(`-p2 ${[...state.Player2].sort((a, b) => a - b).join('')}`);
-  if (state.Wallpaper !== TOGGLE_DEFAULTS.Wallpaper)
-    args.push(`-w ${state.Wallpaper}`);
+  // Wallpaper is no longer chosen independently: the applied wallpaper
+  // (`-w N`) always tracks the window style the user is previewing.
+  if (state.WindowStyle !== TOGGLE_DEFAULTS.Wallpaper)
+    args.push(`-w ${state.WindowStyle}`);
   if (!deepEq(state.font, FONT_DEFAULT))
     args.push(`-f ${rgbStr(state.font)}`);
   for (let w = 1; w <= 8; w++) {
@@ -1762,7 +1739,9 @@ const FLAG_MAP = {
   '-r':   { key: 'Reequip'  },
   '-so':  { key: 'SpellOrder', int: true },
   '-ctrl':{ key: 'Controller'  },
-  '-w':   { key: 'Wallpaper',  int: true },
+  // `-w N` is the applied wallpaper, which now drives the previewed window
+  // style so a loaded config shows the window it was saved against.
+  '-w':   { key: 'WindowStyle', int: true },
 };
 
 function applyFlagString(flags) {
@@ -1803,10 +1782,8 @@ function applyFlagString(flags) {
     i++;
   }
 
-  // Sync side panels + canvas to the freshly-loaded state.
-  document.getElementById('window-style').value = String(state.WindowStyle);
-  document.getElementById('wallpaper').value    = String(state.Wallpaper);
-  document.getElementById('controller').value   = state.Controller;
+  // Window style, wallpaper, and controller are all reflected on the canvas
+  // and side panel, so there are no dropdowns left to sync here.
   return loadWindowAssets(state.WindowStyle).then(() => {
     updateTabUI();
     syncSidePanel();
@@ -1834,6 +1811,16 @@ if (typeof window !== 'undefined') {
   // the menu preview so the custom graphics overlay updates.
   window.ff6c.refresh = function () {
     render();
+  };
+  // Switch the previewed/edited window style from outside the configurator
+  // (the designer used to do this by poking the now-removed dropdown).
+  // Reloads that window's art, then re-syncs everything that depends on it.
+  window.ff6c.setWindowStyle = function (n) {
+    state.WindowStyle = n;
+    return loadWindowAssets(n).then(() => {
+      syncSidePanel(); render(); updateFlagString();
+      notifyStateChange({ kind: 'windowStyle', value: n });
+    });
   };
   window.ff6c.applyFlagString = applyFlagString;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -116,10 +116,12 @@ main {
   border-radius: 4px;
 }
 .warn {
-  margin-left: 12px;
+  margin: 0 0 8px 0;
   font-size: 12px;
   color: #fc8;
 }
+/* Don't reserve vertical space when there's no warning to show. */
+.warn:empty { display: none; }
 .p2-toggles {
   display: flex;
   gap: 12px;
@@ -227,20 +229,42 @@ button:active { background: #2a2a3e; }
 
 .designer-grid {
   display: grid;
-  grid-template-columns: minmax(240px, 1fr) minmax(240px, 1fr) auto;
+  /* col 1: input controls · col 2: canvas · col 3: paint tools */
+  grid-template-columns: minmax(240px, 1fr) auto minmax(240px, 1fr);
   gap: 20px;
   align-items: start;
 }
 
-.designer-output {
-  margin-top: 20px;
-  max-width: 320px;
+/* Full-width note under the three designer columns. */
+.designer-note {
+  margin: 16px 0 0 0;
+  font-size: 12px;
+  color: #889;
 }
-.designer-output .hint { margin: 8px 0 0 0; color: #aab; font-size: 13px; }
+
+/* Export / patch tile at the bottom of the page. */
+.output-tile {
+  margin-top: 24px;
+  padding: 16px;
+  background: #21212a;
+  border: 1px solid #383846;
+  border-radius: 8px;
+}
+.output-tile h2 {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  color: #cdf;
+}
+.output-tile .hint { margin: 12px 0 0 0; color: #aab; font-size: 13px; }
+.output-tile code { background: #15151b; padding: 1px 4px; border-radius: 3px; color: #cfe; }
+.output-actions {
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+.output-actions > * { flex: 1 1 280px; }
 .ds-patch-rom {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid #444;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -329,12 +353,6 @@ button:active { background: #2a2a3e; }
   word-break: break-all;
 }
 .ds-status.error { color: #fc8; }
-
-.designer-canvas-wrap .hint {
-  margin-top: 8px;
-  font-size: 12px;
-  color: #889;
-}
 
 .ds-window-banner {
   padding: 8px 10px;


### PR DESCRIPTION
- Move "Export configuration (.json)" and "Patch a ROM" into a new "Export & patch" tile at the bottom of the page, side by side, since they bundle up everything changed above rather than just the window image.
- Remove the Preview window style, Wallpaper, and Controller dropdowns; all three are chosen directly on the simulated menu. The side tile now only carries the Player-2 battle-slot assignment and hides itself outside "multiple" mode.
- Tie the applied wallpaper (-w N) to the previewed window style so the flagstring and a loaded config always match what's on screen.
- Rewrite the Custom window image blurb around the .json config workflow (--config ff6config.json) instead of the old .bin / .bmp wording.
- Reorder the designer columns to input | canvas | tools, move "Revert this window" under "Export .bmp", and run the painting instructions as a full-width note beneath the three columns.