### PR TITLE
Split Export & patch into side-by-side Export / Patch tiles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
       A web app to make and customize menu configuration files for
       patching <a href="https://ff6worldscollide.com/">FF6 Worlds Collide</a> roms.
       See <a href="https://github.com/HansGR/WorldsCollide/tree/ff6_customize_config_window">the project code</a>
-      for information on how to patch roms.  Designed by DoctorDT.
+      for information on how to patch roms.  Designed by DoctorDT, coded by Claude.
     </p>
     <p class="hint">
       Arrow keys / WASD = move cursor &middot; Enter / Space = toggle &middot;
@@ -210,21 +210,28 @@
        two actions bundle up everything changed above, not just the window
        image. -->
   <section class="output-tile">
-    <h2>Export &amp; patch</h2>
-    <div class="output-actions">
-      <button id="ds-download" type="button">Export configuration (.json)</button>
-      <div class="ds-patch-rom">
-        <label class="ds-upload-config" for="ds-rom-upload">Patch a ROM (.smc / .sfc):</label>
-        <input type="file" id="ds-rom-upload" accept=".smc,.sfc,application/octet-stream">
+    <div class="output-split">
+      <div class="output-col output-export">
+        <h2>Export</h2>
+        <p class="hint">
+          Bundle settings and custom window images into a
+          <code>ff6config.json</code> file.
+        </p>
+        <button id="ds-download" type="button">Export configuration (.json)</button>
+      </div>
+      <div class="output-col output-patch">
+        <div class="output-col-head">
+          <h2>Patch</h2>
+          <input type="file" id="ds-rom-upload" accept=".smc,.sfc,application/octet-stream">
+        </div>
+        <p class="hint">
+          Apply this configuration to your
+          <a href="https://ff6worldscollide.com/">Worlds Collide</a> ROM and
+          return the patched copy.
+        </p>
         <button id="ds-rom-patch" type="button">Patch &amp; download ROM</button>
       </div>
     </div>
-    <p class="hint">
-      <em>Export configuration (.json)</em> bundles settings and
-      custom window images into a <code>ff6config.json</code> file.
-      <em>Patch a ROM</em> applies the configuration to your <a href="https://ff6worldscollide.com/">Worlds Collide</a> ROM and
-      returns the patched copy.  
-    </p>
     <div id="ds-status" class="ds-status"></div>
   </section>
 

--- a/web/style.css
+++ b/web/style.css
@@ -268,20 +268,44 @@ button:active { background: #2a2a3e; }
 }
 .output-tile .hint { margin: 12px 0 0 0; color: #aab; font-size: 13px; }
 .output-tile code { background: #15151b; padding: 1px 4px; border-radius: 3px; color: #cfe; }
-.output-actions {
+/* Two side-by-side tiles: Export on the left, Patch on the right. */
+.output-split {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 16px;
-  align-items: flex-start;
+  align-items: stretch;
 }
-.output-actions > * { width: 100%; max-width: 360px; }
-.ds-patch-rom {
+.output-col {
+  flex: 1 1 280px;
+  min-width: 280px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  padding: 12px;
+  background: #1b1b22;
+  border: 1px solid #383846;
+  border-radius: 6px;
 }
-.ds-patch-rom .ds-upload-config { color: #aab; font-size: 13px; }
-.ds-patch-rom input[type=file] { color: #cfe; font-size: 12px; }
+.output-col h2 { margin: 0; }
+/* Browse... file picker sits on the same line as the Patch title so the
+   two columns line up and their action buttons share the same elevation. */
+.output-col-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.output-col-head input[type=file] {
+  color: #cfe;
+  font-size: 12px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* margin-top:auto pins each button to the bottom of its (equal-height)
+   column, keeping the two buttons at the same y elevation. */
+.output-col button {
+  margin-top: auto;
+  width: 100%;
+}
+.output-col .hint { margin: 12px 0 16px 0; }
 
 .designer-controls fieldset {
   border: 1px solid #444;


### PR DESCRIPTION
Reworks the bottom section into two equal-height tiles with their own helper text. The Browse... ROM picker sits on the same line as the Patch title, and both action buttons are pinned to the bottom of their columns so they share the same y elevation.

Also credits Claude alongside the designer.