### PR TITLE
Fix Python 3.11+ incompatibility: don't size int-like values with len()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ $py.class
 *-flag.json
 wip/
 ffiii_wc_*
+# ROM files (never commit - legal)
+*.smc
+*.sfc

--- a/memory/space.py
+++ b/memory/space.py
@@ -87,10 +87,15 @@ class Space():
         self._update_label_pointers()
 
     def clear(self, value):
-        try:
-            values = [value] * (len(self) // len(value))
-        except:
+        # int-like fills (incl. IntEnum/IntFlag, whose len() returns a popcount
+        # on Python 3.11+) occupy one byte each.
+        if isinstance(value, int):
             values = [value] * len(self)
+        else:
+            try:
+                values = [value] * (len(self) // len(value))
+            except:
+                values = [value] * len(self)
 
         values = self._invoke_callables(values)
         assert len(self) == len(values) # do values evenly fill space?
@@ -175,10 +180,18 @@ class Space():
                 index += size
             else:
                 new_values.append(value)
-                try:
-                    index += len(value)
-                except:
+                # A flattened scalar byte value occupies one byte. int covers
+                # plain ints and IntEnum/IntFlag members (e.g. Flash, Status).
+                # NB: Python 3.11+ added len() to IntFlag (returns the popcount),
+                # so we must NOT use len() to size int-like values or the byte
+                # count desyncs and label pointers land at the wrong address.
+                if isinstance(value, int):
                     index += 1
+                else:
+                    try:
+                        index += len(value)
+                    except TypeError:
+                        index += 1
         return new_values
 
     def _update_label_pointers(self):
@@ -287,10 +300,15 @@ def Write(destination, data, description):
     data = flatten(data)
     for value in data:
         if not isinstance(value, str):
-            try:
-                size += len(value)
-            except TypeError:
+            # int-like values (incl. IntEnum/IntFlag, whose len() returns a
+            # popcount on Python 3.11+) occupy one byte each.
+            if isinstance(value, int):
                 size += 1
+            else:
+                try:
+                    size += len(value)
+                except TypeError:
+                    size += 1
 
     if isinstance(destination, Bank):
         space = Allocate(destination, size, description)


### PR DESCRIPTION
`-ruin` / `-drdc` builds crashed on Python 3.11+ with `TypeError: 'NoneType' object cannot be interpreted as an integer` at the final ROM write, while succeeding on 3.10.

Root cause: Python 3.11 added `__len__` to `IntFlag`, returning the number of set flags (popcount) instead of raising `TypeError`. The byte-counting logic in memory/space.py used `try: n += len(value) except: n += 1`, relying on len() raising for scalar byte values. Instruction args that are IntFlag/IntEnum members (e.g. `Flash.WHITE` = 224, three bits set) therefore counted as 3 bytes instead of 1 on 3.11+. In `_parse_labels` this desynced the running byte offset, so forward label pointers were written 2 bytes past their placeholders, leaving unresolved `None` bytes in the ROM.

This was layout-dependent (hence "works on 3.10, fails on 3.12"): door randomization places events differently across Python versions because the string hash changed in 3.11 (SipHash-2-4 -> SipHash-1-3), so the desync only surfaced when a multi-bit flag preceded a forward branch (e.g. the ruination Phantom Train restaurant: FlashScreen(Flash.WHITE) before BranchChance).

Fix: treat `int` instances (which include IntEnum/IntFlag) as one byte in the three byte-counting sites - `_parse_labels`, `clear`, and `Write` size - so counts match the actual emitted bytes on every interpreter. No behaviour change on 3.10; 3.11 and 3.12 now produce byte-identical output.

https://claude.ai/code/session_01Tvbr7PfXazsR3SAPXUMKmc