### PR TITLE
Disable y-party switching on the floating continent (ruination)

### DIFF
--- a/event/floating_continent.py
+++ b/event/floating_continent.py
@@ -29,6 +29,9 @@ class FloatingContinent(Event):
         self.entry_id = 1556
         self.exit_id = 1557
 
+        if self.args.ruination_mode:
+            self.create_y_party_switch_events()
+
         self.shadow_leaves_mod()
         self.airship_battle_mod()
         if not self.args.fixed_encounters_original:
@@ -70,6 +73,42 @@ class FloatingContinent(Event):
 
         if self.MAP_SHUFFLE:
             self.map_shuffle_mod()
+
+    def create_y_party_switch_events(self):
+        # Temporary fix: in ruination mode, pressing "y" to switch to another party
+        # while on the floating continent resets the event's dynamic map edits and can
+        # softlock the player.  Until a more complete fix exists, disable y-party
+        # switching while on the floating continent and restore it on leaving.  This is
+        # the same approach fanatics tower uses (see FanaticsTower.ruination_mod); we
+        # reuse the SAVED_Y_PARTY_SWITCHING event bit since the two uses cannot overlap.
+
+        # Save ENABLE_Y_PARTY_SWITCHING to SAVED_Y_PARTY_SWITCHING, then clear it
+        src = [
+            field.BranchIfEventBitSet(event_bit.ENABLE_Y_PARTY_SWITCHING, "Y_WAS_ON"),
+            field.ClearEventBit(event_bit.SAVED_Y_PARTY_SWITCHING),
+            field.Branch("DONE_SAVE"),
+            "Y_WAS_ON",
+            field.SetEventBit(event_bit.SAVED_Y_PARTY_SWITCHING),
+            "DONE_SAVE",
+            field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            field.Return(),
+        ]
+        space = Write(Bank.CB, src, "floating continent save and disable y-party switching")
+        self.disable_y_switch_event = space.start_address
+
+        # Restore ENABLE_Y_PARTY_SWITCHING from SAVED_Y_PARTY_SWITCHING
+        src = [
+            field.BranchIfEventBitSet(event_bit.SAVED_Y_PARTY_SWITCHING, "Y_WAS_ON"),
+            field.ClearEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            field.Branch("DONE_RESTORE"),
+            "Y_WAS_ON",
+            field.SetEventBit(event_bit.ENABLE_Y_PARTY_SWITCHING),
+            "DONE_RESTORE",
+            field.ClearEventBit(event_bit.SAVED_Y_PARTY_SWITCHING),
+            field.Return(),
+        ]
+        space = Write(Bank.CB, src, "floating continent restore y-party switching")
+        self.restore_y_switch_event = space.start_address
 
     def shadow_leaves_mod(self):
         # remove shadow from party at floating continent (if return to airship or after atma)
@@ -484,7 +523,12 @@ class FloatingContinent(Event):
 
         space = Reserve(0xa48cc, 0xa48cf, "floating continent do not clear shadow bits if don't wait at airship", field.NOP())
 
-        src = [
+        # Restore y-party switching when leaving the floating continent via the ending
+        # event (the escape sequence after defeating Nerapa).
+        src = []
+        if self.args.ruination_mode:
+            src += [field.Call(self.restore_y_switch_event)]
+        src += [
             field.SetEventBit(event_bit.FINISHED_FLOATING_CONTINENT),
             field.StopScreenShake(),
             field.FreeScreen(),
@@ -681,9 +725,14 @@ class FloatingContinent(Event):
                 field.Branch("LEAVE_FC"),
                 "HAVE_SHADOW",
             ]
+        # Disable y-party switching as soon as the player commits to landing.  GO_TO_FC
+        # is the common point for both landing cases (fighting boss #2 and, on a return
+        # visit, skipping it via SKIP_FC_BOSS2), so a single call covers both.
+        disable_y_switch = [field.Call(self.disable_y_switch_event)] if self.args.ruination_mode else []
         src += [
             field.DialogBranch(self.go_to_FC_dialog, "GO_TO_FC", "LEAVE_FC"),
             "GO_TO_FC",
+        ] + disable_y_switch + [
             # If already defeated Boss #2, just go to FC
             field.BranchIfEventBitSet(event_bit.DEFEATED_AIR_FORCE, "SKIP_FC_BOSS2"),  # custom event bit
             field.Dialog(self.something_curious_dialog, wait_for_input=True),
@@ -766,7 +815,12 @@ class FloatingContinent(Event):
 
         # (5) Modify warp behavior
         # We will add a new event bit to track special warp to Blackjack
-        src_warp = [
+        # Restore y-party switching when leaving the floating continent via the early
+        # path (warping back to the airship before completing the event).
+        src_warp = []
+        if self.args.ruination_mode:
+            src_warp += [field.Call(self.restore_y_switch_event)]
+        src_warp += [
             field.ClearEventBit(event_bit.FLOATING_CONTINENT_WARP_OPTION),
             field.ClearEventBit(event_bit.IN_WOR),
             field.LoadMap(map_id=0x006, x=16, y=6, direction=direction.LEFT,


### PR DESCRIPTION
Pressing y to switch parties while on the floating continent resets the event's dynamic map edits and can softlock the player. As a temporary fix (mirroring fanatics tower), disable y-party switching when landing on the floating continent and restore it when leaving.

- Add create_y_party_switch_events(): save/disable and restore subroutines, reusing the SAVED_Y_PARTY_SWITCHING event bit (uses cannot overlap).
- Disable at GO_TO_FC, the common point for both landing cases (fighting boss #2 and, on a return visit, skipping it).
- Restore on the early path (warp back to the airship) and on the ending event (escape after Nerapa).

https://claude.ai/code/session_01DDpYCkD5c7tpPW5T9PDtBs